### PR TITLE
Add persisted agent model selection

### DIFF
--- a/docs/architecture/boundaries.md
+++ b/docs/architecture/boundaries.md
@@ -21,4 +21,7 @@
   person reads for CLI, agent, and web clients.
 - Generic agent policy is separate from the user profile, which defaults to
   `context/`.
+- Core owns the supported agent-model catalog and preference validation; web
+  owns its HTTP contract and control, while data stores only generic key/value
+  settings.
 - Private context never belongs in application source control.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -37,6 +37,12 @@ between side-panel and full-screen layouts keeps one mounted agent session and
 does not change the agent or HTTP contracts. Full-screen layout places identity
 and controls in a full-height left rail.
 
+The core application owns the typed agent-model catalog and settings service.
+The web API reads and updates the selected model through that service, and each
+agent request resolves the setting before constructing its model. The generic
+`application_settings` table persists the preference; `CODEX_AGENT_MODEL`
+supplies a validated startup default only when no preference is stored.
+
 Gigs, people, gig-person relationships, tasks, and
 meetings expose caller-neutral query/read services from `GigFinderApplication`;
 agent tools receive only those narrow capabilities. Document lookup uses a
@@ -62,6 +68,8 @@ facade.
   snapshots rather than guessing historical attendees.
 - Managed documents and their immutable versions live in the document tables;
   legacy job-description and interview-prep files remain filesystem artifacts.
+- `application_settings` stores operator preferences outside entity revision
+  history; the core service validates values before the generic adapter writes.
 - Person identity, relationship, and outreach share `people` and
   `person_history`; migration 0013 coalesces legacy snapshots by Person ID and
   change ID before removing the separate networking tables.

--- a/docs/product/overview.md
+++ b/docs/product/overview.md
@@ -19,6 +19,8 @@ GigFinder is a local-first workspace for managing a candidate's opportunity pipe
   opens as a resizable side panel and can expand to fill the application without
   resetting the active session. Full-screen mode uses a narrow left rail for
   agent identity and workspace controls.
+- The agent header selects GPT-5.6 Sol, Terra, or Luna. The saved choice applies
+  to the next request, survives restarts, and does not alter an active response.
 - Agent conversations last only for the current page load.
 
 ## Entities

--- a/src/agent/codex-provider.ts
+++ b/src/agent/codex-provider.ts
@@ -2,6 +2,11 @@ import { readFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import path from "node:path";
 import { createOpenAI } from "@ai-sdk/openai";
+import {
+  defaultAgentModelId,
+  parseAgentModelId,
+  type AgentModelId,
+} from "../core/src/application-settings";
 
 interface CodexAuth {
   tokens?: {
@@ -16,9 +21,6 @@ interface CodexJwtClaims {
     chatgpt_account_id?: string;
   };
 }
-
-const supportedModels = ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"] as const;
-export type CodexModelId = typeof supportedModels[number];
 
 function decodeClaims(token: string): CodexJwtClaims {
   const payload = token.split(".")[1];
@@ -47,11 +49,9 @@ async function loadCodexCredential() {
 }
 
 export async function createCodexLanguageModel(
-  modelId = (process.env.CODEX_AGENT_MODEL ?? "gpt-5.6-sol") as CodexModelId,
+  modelId: AgentModelId = defaultAgentModelId,
 ) {
-  if (!supportedModels.includes(modelId)) {
-    throw new Error(`Unsupported Codex model: ${modelId}.`);
-  }
+  const selectedModel = parseAgentModelId(modelId);
   const credential = await loadCodexCredential();
   const codexFetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
     const headers = new Headers(init?.headers);
@@ -69,5 +69,5 @@ export async function createCodexLanguageModel(
     apiKey: "managed-by-codex-provider",
     fetch: codexFetch,
   });
-  return provider.responses(modelId);
+  return provider.responses(selectedModel);
 }

--- a/src/core/src/application-settings.ts
+++ b/src/core/src/application-settings.ts
@@ -1,0 +1,51 @@
+import { DomainValidationError } from "./errors";
+import type { ApplicationSettingsRepository } from "./ports";
+
+export const agentModelCatalog = [
+  { id: "gpt-5.6-sol", label: "GPT-5.6 Sol" },
+  { id: "gpt-5.6-terra", label: "GPT-5.6 Terra" },
+  { id: "gpt-5.6-luna", label: "GPT-5.6 Luna" },
+] as const;
+
+export type AgentModelId = typeof agentModelCatalog[number]["id"];
+
+export const defaultAgentModelId: AgentModelId = "gpt-5.6-sol";
+
+export interface ApplicationSettings {
+  agentModel: AgentModelId;
+}
+
+const agentModelSettingKey = "agent_model";
+
+export function isAgentModelId(value: unknown): value is AgentModelId {
+  return typeof value === "string"
+    && agentModelCatalog.some(model => model.id === value);
+}
+
+export function parseAgentModelId(value: unknown): AgentModelId {
+  if (isAgentModelId(value)) return value;
+  throw new DomainValidationError(
+    `Agent model must be one of: ${agentModelCatalog.map(model => model.id).join(", ")}.`,
+  );
+}
+
+export class ApplicationSettingsService {
+  constructor(
+    private readonly repository: ApplicationSettingsRepository,
+    private readonly defaultAgentModel: AgentModelId = defaultAgentModelId,
+  ) {}
+
+  get(): ApplicationSettings {
+    const stored = this.repository.get(agentModelSettingKey);
+    return {
+      agentModel: stored === null
+        ? this.defaultAgentModel
+        : parseAgentModelId(stored),
+    };
+  }
+
+  setAgentModel(agentModel: AgentModelId): ApplicationSettings {
+    this.repository.set(agentModelSettingKey, agentModel);
+    return { agentModel };
+  }
+}

--- a/src/core/src/application.ts
+++ b/src/core/src/application.ts
@@ -5,14 +5,20 @@ import { ChangeExecutor, ChangeService } from "./changes";
 import { ManagedDocumentService } from "./documents";
 import { SearchContextService } from "./context-search";
 import { ApplicationDocumentReader } from "./document-reader";
+import {
+  ApplicationSettingsService,
+  defaultAgentModelId,
+  type AgentModelId,
+} from "./application-settings";
 
 /** Application API shared by the web server, CLI, and automation. */
 export class GigFinderApplication {
-  readonly gigs:GigDomainService;readonly people:PeopleService;readonly tasks:TaskDomainService;readonly meetings:MeetingService;readonly gigPeople:GigPeopleService;readonly events:EventService;readonly history:HistoryService;readonly changes:ChangeService;readonly artifacts:ArtifactDomainService;readonly documents:ManagedDocumentService;readonly documentReader:ApplicationDocumentReader;readonly contextSearch:SearchContextService;
-  constructor(persistence:Persistence,audit:AuditPort,artifacts:ArtifactPort){
+  readonly gigs:GigDomainService;readonly people:PeopleService;readonly tasks:TaskDomainService;readonly meetings:MeetingService;readonly gigPeople:GigPeopleService;readonly events:EventService;readonly history:HistoryService;readonly changes:ChangeService;readonly artifacts:ArtifactDomainService;readonly documents:ManagedDocumentService;readonly documentReader:ApplicationDocumentReader;readonly contextSearch:SearchContextService;readonly settings:ApplicationSettingsService;
+  constructor(persistence:Persistence,audit:AuditPort,artifacts:ArtifactPort,defaultAgentModel:AgentModelId=defaultAgentModelId){
     const changeExecutor=new ChangeExecutor(persistence);
     this.documents=new ManagedDocumentService(persistence);this.gigs=new GigDomainService(persistence,artifacts,changeExecutor,this.documents);this.people=new PeopleService(persistence,changeExecutor,this.documents);this.tasks=new TaskDomainService(persistence);this.meetings=new MeetingService(persistence,this.gigs,this.people,changeExecutor);this.gigPeople=new GigPeopleService(persistence,this.gigs,this.people);this.events=new EventService(persistence);this.history=new HistoryService(audit);this.changes=new ChangeService(persistence);this.artifacts=new ArtifactDomainService(persistence,artifacts);
     this.documentReader=new ApplicationDocumentReader({gigs:this.gigs,people:this.people,managed:this.documents});
     this.contextSearch=new SearchContextService({gigs:this.gigs,people:this.people});
+    this.settings=new ApplicationSettingsService(persistence.settings,defaultAgentModel);
   }
 }

--- a/src/core/src/index.ts
+++ b/src/core/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./application";
+export * from "./application-settings";
 export * from "./changes";
 export * from "./document-reader";
 export * from "./documents";

--- a/src/core/src/ports.ts
+++ b/src/core/src/ports.ts
@@ -29,8 +29,12 @@ export interface DocumentWriteRepository extends DocumentReadRepository {
     changeSummary: string;
   }): ManagedDocumentRecord;
 }
+export interface ApplicationSettingsRepository {
+  get(key: string): string | null;
+  set(key: string, value: string): void;
+}
 export interface UnitOfWork{gigs:WriteRepository<GigData>;people:WriteRepository<PersonData>;gigPeople:WriteRepository<GigPersonData>;tasks:WriteRepository<TaskData>;meetings:WriteRepository<MeetingData>;meetingParticipants:ReversibleCreateRepository<MeetingParticipantData>;documents:DocumentWriteRepository;recordEvent(input:BusinessEventInput):string}
-export interface Persistence{gigs:ReadRepository<GigData>;people:ReadRepository<PersonData>;gigPeople:ReadRepository<GigPersonData>;tasks:ReadRepository<TaskData>;meetings:ReadRepository<MeetingData>;meetingParticipants:ReadRepository<MeetingParticipantData>;documents:DocumentReadRepository;change<T>(context:ChangeContext,action:(transaction:UnitOfWork)=>T):ChangeResult<T>;revertChange(context:ChangeContext,targetChangeId:string):ChangeResult<RevertedRecord[]>}
+export interface Persistence{gigs:ReadRepository<GigData>;people:ReadRepository<PersonData>;gigPeople:ReadRepository<GigPersonData>;tasks:ReadRepository<TaskData>;meetings:ReadRepository<MeetingData>;meetingParticipants:ReadRepository<MeetingParticipantData>;documents:DocumentReadRepository;settings:ApplicationSettingsRepository;change<T>(context:ChangeContext,action:(transaction:UnitOfWork)=>T):ChangeResult<T>;revertChange(context:ChangeContext,targetChangeId:string):ChangeResult<RevertedRecord[]>}
 export interface AuditPort{query(query:AuditQuery):Record<string,unknown>|Record<string,unknown>[]|null}
 export interface ArtifactPort{jobDescription(gigId:string):Promise<string>;interviewPrep(gigId:string):Promise<{name:string;content:string}[]>;jobDescriptionExists(gigId:string):Promise<boolean>;interviewPrepExists(gigId:string):Promise<boolean>;verify(expectations:{gigs:{id:string;hasJobDescription:boolean;hasInterviewPrep:boolean}[]}):Promise<ArtifactVerification>}
 export interface ArtifactVerification{ok:boolean;errors:string[];unregistered:string[]}

--- a/src/core/test/application-settings.test.ts
+++ b/src/core/test/application-settings.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+import {
+  agentModelCatalog,
+  ApplicationSettingsService,
+  defaultAgentModelId,
+  parseAgentModelId,
+} from "../src/application-settings";
+
+class MemorySettings {
+  readonly values = new Map<string, string>();
+  get(key: string) { return this.values.get(key) ?? null; }
+  set(key: string, value: string) { this.values.set(key, value); }
+}
+
+describe("application settings", () => {
+  test("uses Sol by default and supports a configured startup default", () => {
+    expect(new ApplicationSettingsService(new MemorySettings()).get())
+      .toEqual({ agentModel: defaultAgentModelId });
+    expect(new ApplicationSettingsService(
+      new MemorySettings(),
+      "gpt-5.6-terra",
+    ).get()).toEqual({ agentModel: "gpt-5.6-terra" });
+  });
+
+  test("persists a selected model over the startup default", () => {
+    const repository = new MemorySettings();
+    const settings = new ApplicationSettingsService(
+      repository,
+      "gpt-5.6-terra",
+    );
+    expect(settings.setAgentModel("gpt-5.6-luna"))
+      .toEqual({ agentModel: "gpt-5.6-luna" });
+    expect(new ApplicationSettingsService(
+      repository,
+      "gpt-5.6-sol",
+    ).get()).toEqual({ agentModel: "gpt-5.6-luna" });
+  });
+
+  test("rejects values outside the shared model catalog", () => {
+    expect(agentModelCatalog.map(model => model.id)).toEqual([
+      "gpt-5.6-sol",
+      "gpt-5.6-terra",
+      "gpt-5.6-luna",
+    ]);
+    expect(() => parseAgentModelId("gpt-unsupported"))
+      .toThrow("Agent model must be one of");
+  });
+});

--- a/src/core/test/read-services.test.ts
+++ b/src/core/test/read-services.test.ts
@@ -101,6 +101,7 @@ function application() {
   const meetings = new Repo<MeetingData>();
   const meetingParticipants = new Repo<MeetingParticipantData>();
   const documents = new EmptyDocuments();
+  const settings = { get: () => null, set: () => undefined };
   let readChanges = 0;
   const persistence: Persistence = {
     gigs,
@@ -110,6 +111,7 @@ function application() {
     meetings,
     meetingParticipants,
     documents,
+    settings,
     change: (changeContext, action) => {
       readChanges += 1;
       return {

--- a/src/core/test/services.test.ts
+++ b/src/core/test/services.test.ts
@@ -20,7 +20,7 @@ class DocumentRepo implements DocumentWriteRepository {
 }
 const documents=new DocumentRepo();
 const recordedEvents:string[]=[];
-const persistence:Persistence={gigs,people,gigPeople,tasks,meetings,meetingParticipants,documents,change:(context,action)=>({changeId:context.changeId??`test-${context.summary}`,value:action({gigs,people,gigPeople,tasks,meetings,meetingParticipants,documents,recordEvent:event=>{recordedEvents.push(event.id??event.type);return event.id??event.type}} as UnitOfWork)}),revertChange:(revertContext,targetChangeId)=>({changeId:revertContext.changeId??`revert-${targetChangeId}`,value:[{entity:"gig",id:"gig"}]})};
+const persistence:Persistence={gigs,people,gigPeople,tasks,meetings,meetingParticipants,documents,settings:{get:()=>null,set:()=>undefined},change:(context,action)=>({changeId:context.changeId??`test-${context.summary}`,value:action({gigs,people,gigPeople,tasks,meetings,meetingParticipants,documents,recordEvent:event=>{recordedEvents.push(event.id??event.type);return event.id??event.type}} as UnitOfWork)}),revertChange:(revertContext,targetChangeId)=>({changeId:revertContext.changeId??`revert-${targetChangeId}`,value:[{entity:"gig",id:"gig"}]})};
 const artifacts:ArtifactPort={jobDescription:async()=>"description",interviewPrep:async()=>[{name:"general.md",content:"prep"}],jobDescriptionExists:async()=>true,interviewPrepExists:async()=>true,verify:async():Promise<ArtifactVerification>=>({ok:true,errors:[],unregistered:[]})};
 const audit:AuditPort={query:query=>({query})};const app=new GigFinderApplication(persistence,audit,artifacts);const context:ChangeContext={actor:"test",source:"test",summary:"change"};
 describe("application services",()=>{

--- a/src/data/drizzle/0014_busy_amphibian.sql
+++ b/src/data/drizzle/0014_busy_amphibian.sql
@@ -1,0 +1,5 @@
+CREATE TABLE `application_settings` (
+	`key` text PRIMARY KEY NOT NULL,
+	`value` text NOT NULL,
+	`updated_at` text NOT NULL
+);

--- a/src/data/drizzle/meta/0014_snapshot.json
+++ b/src/data/drizzle/meta/0014_snapshot.json
@@ -1,0 +1,2984 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "b62a9567-bc81-4133-970d-f8fe911ec6ba",
+  "prevId": "0d1bee5d-034f-4d02-83b4-5d39b4f05a47",
+  "tables": {
+    "application_settings": {
+      "name": "application_settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "business_events": {
+      "name": "business_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "change_id": {
+          "name": "change_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data_json": {
+          "name": "data_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "supersedes_event_id": {
+          "name": "supersedes_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "business_events_entity_idx": {
+          "name": "business_events_entity_idx",
+          "columns": [
+            "entity_type",
+            "entity_id",
+            "occurred_at"
+          ],
+          "isUnique": false
+        },
+        "business_events_change_idx": {
+          "name": "business_events_change_idx",
+          "columns": [
+            "change_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "business_events_change_id_changes_id_fk": {
+          "name": "business_events_change_id_changes_id_fk",
+          "tableFrom": "business_events",
+          "tableTo": "changes",
+          "columnsFrom": [
+            "change_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "changes": {
+      "name": "changes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_change_id": {
+          "name": "parent_change_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'committed'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_sources": {
+      "name": "event_sources",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_system": {
+          "name": "source_system",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_timestamp": {
+          "name": "source_timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_uri": {
+          "name": "source_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "imported_at": {
+          "name": "imported_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "event_sources_event_idx": {
+          "name": "event_sources_event_idx",
+          "columns": [
+            "event_id"
+          ],
+          "isUnique": false
+        },
+        "event_sources_external_idx": {
+          "name": "event_sources_external_idx",
+          "columns": [
+            "source_system",
+            "external_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "event_sources_event_id_business_events_id_fk": {
+          "name": "event_sources_event_id_business_events_id_fk",
+          "tableFrom": "event_sources",
+          "tableTo": "business_events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "gig_history": {
+      "name": "gig_history",
+      "columns": {
+        "history_id": {
+          "name": "history_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "change_id": {
+          "name": "change_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recorded_by": {
+          "name": "recorded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_job_id": {
+          "name": "external_job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stage": {
+          "name": "stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "status_summary": {
+          "name": "status_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_activity": {
+          "name": "last_activity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "next_action_description": {
+          "name": "next_action_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "next_action_due": {
+          "name": "next_action_due",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fit_rating": {
+          "name": "fit_rating",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fit_summary": {
+          "name": "fit_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pay_currency": {
+          "name": "pay_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pay_minimum": {
+          "name": "pay_minimum",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pay_maximum": {
+          "name": "pay_maximum",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pay_period": {
+          "name": "pay_period",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pay_notes": {
+          "name": "pay_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "work_arrangement": {
+          "name": "work_arrangement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "posted_date": {
+          "name": "posted_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "business_unit_team": {
+          "name": "business_unit_team",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "recruiter_source": {
+          "name": "recruiter_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bonus": {
+          "name": "bonus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "equity": {
+          "name": "equity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "other_compensation": {
+          "name": "other_compensation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags_json": {
+          "name": "tags_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "has_job_description": {
+          "name": "has_job_description",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "has_interview_prep": {
+          "name": "has_interview_prep",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "gig_history_entity_idx": {
+          "name": "gig_history_entity_idx",
+          "columns": [
+            "id",
+            "revision"
+          ],
+          "isUnique": false
+        },
+        "gig_history_change_idx": {
+          "name": "gig_history_change_idx",
+          "columns": [
+            "change_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gig_history_change_id_changes_id_fk": {
+          "name": "gig_history_change_id_changes_id_fk",
+          "tableFrom": "gig_history",
+          "tableTo": "changes",
+          "columnsFrom": [
+            "change_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "gig_history_is_deleted_check": {
+          "name": "gig_history_is_deleted_check",
+          "value": "\"gig_history\".\"is_deleted\" in (0, 1)"
+        },
+        "gig_history_operation_check": {
+          "name": "gig_history_operation_check",
+          "value": "\"gig_history\".\"operation\" in ('update', 'delete')"
+        }
+      }
+    },
+    "gig_people": {
+      "name": "gig_people",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "gig_id": {
+          "name": "gig_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "relationship": {
+          "name": "relationship",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "gig_people_relation_idx": {
+          "name": "gig_people_relation_idx",
+          "columns": [
+            "gig_id",
+            "person_id",
+            "relationship"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "gig_people_gig_id_gigs_id_fk": {
+          "name": "gig_people_gig_id_gigs_id_fk",
+          "tableFrom": "gig_people",
+          "tableTo": "gigs",
+          "columnsFrom": [
+            "gig_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "gig_people_person_id_people_id_fk": {
+          "name": "gig_people_person_id_people_id_fk",
+          "tableFrom": "gig_people",
+          "tableTo": "people",
+          "columnsFrom": [
+            "person_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "gig_people_deleted_check": {
+          "name": "gig_people_deleted_check",
+          "value": "\"gig_people\".\"is_deleted\" in (0,1)"
+        }
+      }
+    },
+    "gig_people_history": {
+      "name": "gig_people_history",
+      "columns": {
+        "history_id": {
+          "name": "history_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "change_id": {
+          "name": "change_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recorded_by": {
+          "name": "recorded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "gig_id": {
+          "name": "gig_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "relationship": {
+          "name": "relationship",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "gig_people_history_entity_idx": {
+          "name": "gig_people_history_entity_idx",
+          "columns": [
+            "id",
+            "revision"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gig_people_history_change_id_changes_id_fk": {
+          "name": "gig_people_history_change_id_changes_id_fk",
+          "tableFrom": "gig_people_history",
+          "tableTo": "changes",
+          "columnsFrom": [
+            "change_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "gig_people_history_gig_id_gigs_id_fk": {
+          "name": "gig_people_history_gig_id_gigs_id_fk",
+          "tableFrom": "gig_people_history",
+          "tableTo": "gigs",
+          "columnsFrom": [
+            "gig_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "gig_people_history_person_id_people_id_fk": {
+          "name": "gig_people_history_person_id_people_id_fk",
+          "tableFrom": "gig_people_history",
+          "tableTo": "people",
+          "columnsFrom": [
+            "person_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "gig_people_history_deleted_check": {
+          "name": "gig_people_history_deleted_check",
+          "value": "\"gig_people_history\".\"is_deleted\" in (0,1)"
+        },
+        "gig_people_history_operation_check": {
+          "name": "gig_people_history_operation_check",
+          "value": "\"gig_people_history\".\"operation\" in ('update','delete')"
+        }
+      }
+    },
+    "gigs": {
+      "name": "gigs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_job_id": {
+          "name": "external_job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stage": {
+          "name": "stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "status_summary": {
+          "name": "status_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_activity": {
+          "name": "last_activity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "next_action_description": {
+          "name": "next_action_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "next_action_due": {
+          "name": "next_action_due",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fit_rating": {
+          "name": "fit_rating",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fit_summary": {
+          "name": "fit_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pay_currency": {
+          "name": "pay_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pay_minimum": {
+          "name": "pay_minimum",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pay_maximum": {
+          "name": "pay_maximum",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pay_period": {
+          "name": "pay_period",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pay_notes": {
+          "name": "pay_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "work_arrangement": {
+          "name": "work_arrangement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "posted_date": {
+          "name": "posted_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "business_unit_team": {
+          "name": "business_unit_team",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "recruiter_source": {
+          "name": "recruiter_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bonus": {
+          "name": "bonus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "equity": {
+          "name": "equity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "other_compensation": {
+          "name": "other_compensation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags_json": {
+          "name": "tags_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "has_job_description": {
+          "name": "has_job_description",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "has_interview_prep": {
+          "name": "has_interview_prep",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "gigs_stage_idx": {
+          "name": "gigs_stage_idx",
+          "columns": [
+            "stage"
+          ],
+          "isUnique": false
+        },
+        "gigs_due_idx": {
+          "name": "gigs_due_idx",
+          "columns": [
+            "next_action_due"
+          ],
+          "isUnique": false
+        },
+        "gigs_deleted_idx": {
+          "name": "gigs_deleted_idx",
+          "columns": [
+            "is_deleted"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "gigs_is_deleted_check": {
+          "name": "gigs_is_deleted_check",
+          "value": "\"gigs\".\"is_deleted\" in (0, 1)"
+        }
+      }
+    },
+    "managed_document_links": {
+      "name": "managed_document_links",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "gig_id": {
+          "name": "gig_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "managed_document_links_document_idx": {
+          "name": "managed_document_links_document_idx",
+          "columns": [
+            "document_id"
+          ],
+          "isUnique": false
+        },
+        "managed_document_links_gig_idx": {
+          "name": "managed_document_links_gig_idx",
+          "columns": [
+            "gig_id"
+          ],
+          "isUnique": false
+        },
+        "managed_document_links_person_idx": {
+          "name": "managed_document_links_person_idx",
+          "columns": [
+            "person_id"
+          ],
+          "isUnique": false
+        },
+        "managed_document_links_gig_unique": {
+          "name": "managed_document_links_gig_unique",
+          "columns": [
+            "document_id",
+            "gig_id"
+          ],
+          "isUnique": true
+        },
+        "managed_document_links_person_unique": {
+          "name": "managed_document_links_person_unique",
+          "columns": [
+            "document_id",
+            "person_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "managed_document_links_document_id_managed_documents_id_fk": {
+          "name": "managed_document_links_document_id_managed_documents_id_fk",
+          "tableFrom": "managed_document_links",
+          "tableTo": "managed_documents",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "managed_document_links_gig_id_gigs_id_fk": {
+          "name": "managed_document_links_gig_id_gigs_id_fk",
+          "tableFrom": "managed_document_links",
+          "tableTo": "gigs",
+          "columnsFrom": [
+            "gig_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "managed_document_links_person_id_people_id_fk": {
+          "name": "managed_document_links_person_id_people_id_fk",
+          "tableFrom": "managed_document_links",
+          "tableTo": "people",
+          "columnsFrom": [
+            "person_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "managed_document_links_target_check": {
+          "name": "managed_document_links_target_check",
+          "value": "(\"managed_document_links\".\"gig_id\" is not null and \"managed_document_links\".\"person_id\" is null) or (\"managed_document_links\".\"gig_id\" is null and \"managed_document_links\".\"person_id\" is not null)"
+        }
+      }
+    },
+    "managed_document_versions": {
+      "name": "managed_document_versions",
+      "columns": {
+        "document_id": {
+          "name": "document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_version": {
+          "name": "parent_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "change_id": {
+          "name": "change_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "change_summary": {
+          "name": "change_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "managed_document_versions_change_idx": {
+          "name": "managed_document_versions_change_idx",
+          "columns": [
+            "change_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "managed_document_versions_document_id_managed_documents_id_fk": {
+          "name": "managed_document_versions_document_id_managed_documents_id_fk",
+          "tableFrom": "managed_document_versions",
+          "tableTo": "managed_documents",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "managed_document_versions_change_id_changes_id_fk": {
+          "name": "managed_document_versions_change_id_changes_id_fk",
+          "tableFrom": "managed_document_versions",
+          "tableTo": "changes",
+          "columnsFrom": [
+            "change_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "managed_document_versions_document_id_version_pk": {
+          "columns": [
+            "document_id",
+            "version"
+          ],
+          "name": "managed_document_versions_document_id_version_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "managed_document_versions_version_check": {
+          "name": "managed_document_versions_version_check",
+          "value": "\"managed_document_versions\".\"version\" > 0"
+        },
+        "managed_document_versions_parent_check": {
+          "name": "managed_document_versions_parent_check",
+          "value": "\"managed_document_versions\".\"parent_version\" is null or \"managed_document_versions\".\"parent_version\" < \"managed_document_versions\".\"version\""
+        }
+      }
+    },
+    "managed_documents": {
+      "name": "managed_documents",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_type": {
+          "name": "document_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_description": {
+          "name": "source_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "upload_provenance_json": {
+          "name": "upload_provenance_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "current_version": {
+          "name": "current_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "managed_documents_type_check": {
+          "name": "managed_documents_type_check",
+          "value": "\"managed_documents\".\"document_type\" in ('job_description', 'notes', 'interview_prep', 'profile')"
+        },
+        "managed_documents_media_type_check": {
+          "name": "managed_documents_media_type_check",
+          "value": "\"managed_documents\".\"media_type\" in ('text/plain', 'text/markdown')"
+        },
+        "managed_documents_current_version_check": {
+          "name": "managed_documents_current_version_check",
+          "value": "\"managed_documents\".\"current_version\" > 0"
+        }
+      }
+    },
+    "meeting_history": {
+      "name": "meeting_history",
+      "columns": {
+        "history_id": {
+          "name": "history_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "change_id": {
+          "name": "change_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recorded_by": {
+          "name": "recorded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ends_at": {
+          "name": "ends_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "gig_id": {
+          "name": "gig_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_calendar_id": {
+          "name": "external_calendar_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_event_id": {
+          "name": "external_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "legacy_related_entity_type": {
+          "name": "legacy_related_entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "legacy_related_entity_id": {
+          "name": "legacy_related_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "meeting_history_entity_idx": {
+          "name": "meeting_history_entity_idx",
+          "columns": [
+            "id",
+            "revision"
+          ],
+          "isUnique": false
+        },
+        "meeting_history_change_idx": {
+          "name": "meeting_history_change_idx",
+          "columns": [
+            "change_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meeting_history_change_id_changes_id_fk": {
+          "name": "meeting_history_change_id_changes_id_fk",
+          "tableFrom": "meeting_history",
+          "tableTo": "changes",
+          "columnsFrom": [
+            "change_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "meeting_history_gig_id_gigs_id_fk": {
+          "name": "meeting_history_gig_id_gigs_id_fk",
+          "tableFrom": "meeting_history",
+          "tableTo": "gigs",
+          "columnsFrom": [
+            "gig_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "meeting_history_is_deleted_check": {
+          "name": "meeting_history_is_deleted_check",
+          "value": "\"meeting_history\".\"is_deleted\" in (0, 1)"
+        },
+        "meeting_history_operation_check": {
+          "name": "meeting_history_operation_check",
+          "value": "\"meeting_history\".\"operation\" in ('update', 'delete')"
+        }
+      }
+    },
+    "meeting_participant_history": {
+      "name": "meeting_participant_history",
+      "columns": {
+        "history_id": {
+          "name": "history_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "change_id": {
+          "name": "change_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recorded_by": {
+          "name": "recorded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "meeting_id": {
+          "name": "meeting_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "meeting_participant_history_entity_idx": {
+          "name": "meeting_participant_history_entity_idx",
+          "columns": [
+            "id",
+            "revision"
+          ],
+          "isUnique": false
+        },
+        "meeting_participant_history_change_idx": {
+          "name": "meeting_participant_history_change_idx",
+          "columns": [
+            "change_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meeting_participant_history_change_id_changes_id_fk": {
+          "name": "meeting_participant_history_change_id_changes_id_fk",
+          "tableFrom": "meeting_participant_history",
+          "tableTo": "changes",
+          "columnsFrom": [
+            "change_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "meeting_participant_history_meeting_id_meetings_id_fk": {
+          "name": "meeting_participant_history_meeting_id_meetings_id_fk",
+          "tableFrom": "meeting_participant_history",
+          "tableTo": "meetings",
+          "columnsFrom": [
+            "meeting_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "meeting_participant_history_person_id_people_id_fk": {
+          "name": "meeting_participant_history_person_id_people_id_fk",
+          "tableFrom": "meeting_participant_history",
+          "tableTo": "people",
+          "columnsFrom": [
+            "person_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "meeting_participant_history_deleted_check": {
+          "name": "meeting_participant_history_deleted_check",
+          "value": "\"meeting_participant_history\".\"is_deleted\" in (0, 1)"
+        },
+        "meeting_participant_history_operation_check": {
+          "name": "meeting_participant_history_operation_check",
+          "value": "\"meeting_participant_history\".\"operation\" in ('create', 'update', 'delete')"
+        }
+      }
+    },
+    "meeting_participants": {
+      "name": "meeting_participants",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "meeting_id": {
+          "name": "meeting_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "meeting_participants_relation_idx": {
+          "name": "meeting_participants_relation_idx",
+          "columns": [
+            "meeting_id",
+            "person_id"
+          ],
+          "isUnique": true
+        },
+        "meeting_participants_meeting_idx": {
+          "name": "meeting_participants_meeting_idx",
+          "columns": [
+            "meeting_id"
+          ],
+          "isUnique": false
+        },
+        "meeting_participants_person_idx": {
+          "name": "meeting_participants_person_idx",
+          "columns": [
+            "person_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "meeting_participants_meeting_id_meetings_id_fk": {
+          "name": "meeting_participants_meeting_id_meetings_id_fk",
+          "tableFrom": "meeting_participants",
+          "tableTo": "meetings",
+          "columnsFrom": [
+            "meeting_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "meeting_participants_person_id_people_id_fk": {
+          "name": "meeting_participants_person_id_people_id_fk",
+          "tableFrom": "meeting_participants",
+          "tableTo": "people",
+          "columnsFrom": [
+            "person_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "meeting_participants_deleted_check": {
+          "name": "meeting_participants_deleted_check",
+          "value": "\"meeting_participants\".\"is_deleted\" in (0, 1)"
+        }
+      }
+    },
+    "meetings": {
+      "name": "meetings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ends_at": {
+          "name": "ends_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "gig_id": {
+          "name": "gig_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_calendar_id": {
+          "name": "external_calendar_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_event_id": {
+          "name": "external_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "meetings_start_idx": {
+          "name": "meetings_start_idx",
+          "columns": [
+            "starts_at"
+          ],
+          "isUnique": false
+        },
+        "meetings_deleted_idx": {
+          "name": "meetings_deleted_idx",
+          "columns": [
+            "is_deleted"
+          ],
+          "isUnique": false
+        },
+        "meetings_external_event_idx": {
+          "name": "meetings_external_event_idx",
+          "columns": [
+            "external_calendar_id",
+            "external_event_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "meetings_gig_id_gigs_id_fk": {
+          "name": "meetings_gig_id_gigs_id_fk",
+          "tableFrom": "meetings",
+          "tableTo": "gigs",
+          "columnsFrom": [
+            "gig_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "meetings_is_deleted_check": {
+          "name": "meetings_is_deleted_check",
+          "value": "\"meetings\".\"is_deleted\" in (0, 1)"
+        }
+      }
+    },
+    "people": {
+      "name": "people",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "linkedin_profile_url": {
+          "name": "linkedin_profile_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "connected_on": {
+          "name": "connected_on",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "relationship_type": {
+          "name": "relationship_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'professional_contact'"
+        },
+        "relationship_strength": {
+          "name": "relationship_strength",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "introduced_by": {
+          "name": "introduced_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "relationship_notes": {
+          "name": "relationship_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unranked'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'not_contacted'"
+        },
+        "last_contacted": {
+          "name": "last_contacted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_contact_method": {
+          "name": "last_contact_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_contact_summary": {
+          "name": "last_contact_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "next_action": {
+          "name": "next_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "next_action_due": {
+          "name": "next_action_due",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "why_interesting": {
+          "name": "why_interesting",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes_json": {
+          "name": "notes_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "tags_json": {
+          "name": "tags_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "people_name_idx": {
+          "name": "people_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        },
+        "people_priority_idx": {
+          "name": "people_priority_idx",
+          "columns": [
+            "priority"
+          ],
+          "isUnique": false
+        },
+        "people_due_idx": {
+          "name": "people_due_idx",
+          "columns": [
+            "next_action_due"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "people_deleted_check": {
+          "name": "people_deleted_check",
+          "value": "\"people\".\"is_deleted\" in (0,1)"
+        }
+      }
+    },
+    "person_history": {
+      "name": "person_history",
+      "columns": {
+        "history_id": {
+          "name": "history_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "change_id": {
+          "name": "change_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recorded_by": {
+          "name": "recorded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "linkedin_profile_url": {
+          "name": "linkedin_profile_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "connected_on": {
+          "name": "connected_on",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "relationship_type": {
+          "name": "relationship_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'professional_contact'"
+        },
+        "relationship_strength": {
+          "name": "relationship_strength",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "introduced_by": {
+          "name": "introduced_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "relationship_notes": {
+          "name": "relationship_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unranked'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'not_contacted'"
+        },
+        "last_contacted": {
+          "name": "last_contacted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_contact_method": {
+          "name": "last_contact_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_contact_summary": {
+          "name": "last_contact_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "next_action": {
+          "name": "next_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "next_action_due": {
+          "name": "next_action_due",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "why_interesting": {
+          "name": "why_interesting",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes_json": {
+          "name": "notes_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "tags_json": {
+          "name": "tags_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "person_history_entity_idx": {
+          "name": "person_history_entity_idx",
+          "columns": [
+            "id",
+            "revision"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "person_history_change_id_changes_id_fk": {
+          "name": "person_history_change_id_changes_id_fk",
+          "tableFrom": "person_history",
+          "tableTo": "changes",
+          "columnsFrom": [
+            "change_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "person_history_deleted_check": {
+          "name": "person_history_deleted_check",
+          "value": "\"person_history\".\"is_deleted\" in (0,1)"
+        },
+        "person_history_operation_check": {
+          "name": "person_history_operation_check",
+          "value": "\"person_history\".\"operation\" in ('update','delete')"
+        }
+      }
+    },
+    "task_history": {
+      "name": "task_history",
+      "columns": {
+        "history_id": {
+          "name": "history_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "change_id": {
+          "name": "change_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recorded_by": {
+          "name": "recorded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "related_entity_type": {
+          "name": "related_entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "related_entity_id": {
+          "name": "related_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "related_entity_label": {
+          "name": "related_entity_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "task_history_entity_idx": {
+          "name": "task_history_entity_idx",
+          "columns": [
+            "id",
+            "revision"
+          ],
+          "isUnique": false
+        },
+        "task_history_change_idx": {
+          "name": "task_history_change_idx",
+          "columns": [
+            "change_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "task_history_change_id_changes_id_fk": {
+          "name": "task_history_change_id_changes_id_fk",
+          "tableFrom": "task_history",
+          "tableTo": "changes",
+          "columnsFrom": [
+            "change_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "task_history_is_deleted_check": {
+          "name": "task_history_is_deleted_check",
+          "value": "\"task_history\".\"is_deleted\" in (0, 1)"
+        },
+        "task_history_operation_check": {
+          "name": "task_history_operation_check",
+          "value": "\"task_history\".\"operation\" in ('update', 'delete')"
+        }
+      }
+    },
+    "tasks": {
+      "name": "tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "related_entity_type": {
+          "name": "related_entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "related_entity_id": {
+          "name": "related_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "related_entity_label": {
+          "name": "related_entity_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tasks_status_idx": {
+          "name": "tasks_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "tasks_due_idx": {
+          "name": "tasks_due_idx",
+          "columns": [
+            "due_date"
+          ],
+          "isUnique": false
+        },
+        "tasks_deleted_idx": {
+          "name": "tasks_deleted_idx",
+          "columns": [
+            "is_deleted"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "tasks_is_deleted_check": {
+          "name": "tasks_is_deleted_check",
+          "value": "\"tasks\".\"is_deleted\" in (0, 1)"
+        }
+      }
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/src/data/drizzle/meta/_journal.json
+++ b/src/data/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1785777145698,
       "tag": "0013_vengeful_sentry",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "6",
+      "when": 1785778338461,
+      "tag": "0014_busy_amphibian",
+      "breakpoints": true
     }
   ]
 }

--- a/src/data/src/index.ts
+++ b/src/data/src/index.ts
@@ -7,4 +7,5 @@ export * from "./errors";
 export * from "./maintenance";
 export * from "./meeting-migration";
 export * from "./local-application";
+export * from "./settings-store";
 export * from "./store";

--- a/src/data/src/local-application.ts
+++ b/src/data/src/local-application.ts
@@ -3,9 +3,14 @@ import { AuditReader } from "./audit";
 import { LocalArtifactStore } from "./artifacts";
 import { openDatabase } from "./database";
 import { DataStore } from "./store";
+import {
+  defaultAgentModelId,
+  type AgentModelId,
+} from "../../core/src/application-settings";
 
 export interface LocalApplicationPaths { database: string; artifacts: string }
-export function openLocalApplication(paths:LocalApplicationPaths){
+export interface LocalApplicationOptions { defaultAgentModel?: AgentModelId }
+export function openLocalApplication(paths:LocalApplicationPaths,options:LocalApplicationOptions={}){
   const database=openDatabase(paths.database,{create:false});
-  return {application:new GigFinderApplication(new DataStore(database),new AuditReader(database),new LocalArtifactStore(paths.artifacts)),close:()=>database.close()};
+  return {application:new GigFinderApplication(new DataStore(database),new AuditReader(database),new LocalArtifactStore(paths.artifacts),options.defaultAgentModel??defaultAgentModelId),close:()=>database.close()};
 }

--- a/src/data/src/schema.ts
+++ b/src/data/src/schema.ts
@@ -26,6 +26,12 @@ export const changes = sqliteTable("changes", {
   status: text("status", { enum: ["committed"] }).notNull().default("committed"),
 });
 
+export const applicationSettings = sqliteTable("application_settings", {
+  key: text("key").primaryKey(),
+  value: text("value").notNull(),
+  updatedAt: text("updated_at").notNull(),
+});
+
 const gigFields = {
   id: text("id").notNull(),
   company: text("company").notNull(),

--- a/src/data/src/settings-store.ts
+++ b/src/data/src/settings-store.ts
@@ -1,0 +1,24 @@
+import type { Database } from "bun:sqlite";
+import type { ApplicationSettingsRepository } from "../../core/src/ports";
+
+export class SqliteApplicationSettingsRepository
+implements ApplicationSettingsRepository {
+  constructor(private readonly database: Database) {}
+
+  get(key: string): string | null {
+    const row = this.database.query(
+      "SELECT value FROM application_settings WHERE key = ?",
+    ).get(key) as { value: string } | null;
+    return row?.value ?? null;
+  }
+
+  set(key: string, value: string): void {
+    this.database.query(`
+      INSERT INTO application_settings (key, value, updated_at)
+      VALUES (?, ?, ?)
+      ON CONFLICT(key) DO UPDATE SET
+        value = excluded.value,
+        updated_at = excluded.updated_at
+    `).run(key, value, new Date().toISOString());
+  }
+}

--- a/src/data/src/store.ts
+++ b/src/data/src/store.ts
@@ -6,6 +6,7 @@ import {
   SqliteDocumentReadRepository,
   SqliteDocumentWriteRepository,
 } from "./document-store";
+import { SqliteApplicationSettingsRepository } from "./settings-store";
 
 type Scalar = string | number | boolean | null;
 type DataRecord = { id: string };
@@ -211,8 +212,8 @@ export class ChangeTransaction {
 }
 
 export class DataStore {
-  readonly gigs: ReadRepository<GigData>;readonly people:ReadRepository<PersonData>;readonly gigPeople:ReadRepository<GigPersonData>; readonly tasks: ReadRepository<TaskData>; readonly meetings: ReadRepository<MeetingData>; readonly meetingParticipants: ReadRepository<MeetingParticipantData>; readonly documents: SqliteDocumentReadRepository;
-  constructor(private readonly database: Database) { this.gigs = new ReadRepository(database, configs.gigs);this.people=new ReadRepository(database,configs.people);this.gigPeople=new ReadRepository(database,configs.gigPeople); this.tasks = new ReadRepository(database, configs.tasks); this.meetings = new ReadRepository(database, configs.meetings); this.meetingParticipants = new ReadRepository(database, configs.meetingParticipants); this.documents = new SqliteDocumentReadRepository(database); }
+  readonly gigs: ReadRepository<GigData>;readonly people:ReadRepository<PersonData>;readonly gigPeople:ReadRepository<GigPersonData>; readonly tasks: ReadRepository<TaskData>; readonly meetings: ReadRepository<MeetingData>; readonly meetingParticipants: ReadRepository<MeetingParticipantData>; readonly documents: SqliteDocumentReadRepository;readonly settings:SqliteApplicationSettingsRepository;
+  constructor(private readonly database: Database) { this.gigs = new ReadRepository(database, configs.gigs);this.people=new ReadRepository(database,configs.people);this.gigPeople=new ReadRepository(database,configs.gigPeople); this.tasks = new ReadRepository(database, configs.tasks); this.meetings = new ReadRepository(database, configs.meetings); this.meetingParticipants = new ReadRepository(database, configs.meetingParticipants); this.documents = new SqliteDocumentReadRepository(database);this.settings=new SqliteApplicationSettingsRepository(database); }
   change<T>(context: ChangeContext, action: (transaction: ChangeTransaction) => T): ChangeResult<T> {
     if (!context.actor.trim() || !context.summary.trim()) throw new Error("Change actor and summary are required.");
     const changeId = context.changeId ?? id("chg");

--- a/src/data/test/store.test.ts
+++ b/src/data/test/store.test.ts
@@ -48,7 +48,7 @@ describe("migrations", () => {
   });
   test("creates every live, history, change, event, and source table", () => {
     const names = database.query("SELECT name FROM sqlite_master WHERE type = 'table'").all().map((row) => String((row as {name:string}).name));
-    for (const table of ["gigs","gig_history","people","person_history","gig_people","gig_people_history","tasks","task_history","meetings","meeting_history","meeting_participants","meeting_participant_history","changes","business_events","event_sources","managed_documents","managed_document_versions","__drizzle_migrations"]) expect(names).toContain(table);
+    for (const table of ["gigs","gig_history","people","person_history","gig_people","gig_people_history","tasks","task_history","meetings","meeting_history","meeting_participants","meeting_participant_history","changes","application_settings","business_events","event_sources","managed_documents","managed_document_versions","__drizzle_migrations"]) expect(names).toContain(table);
     expect(names).not.toContain("networking_contacts");
     expect(names).not.toContain("networking_contact_history");
   });
@@ -185,13 +185,30 @@ describe("migrations", () => {
     const directory = await mkdtemp(path.join(tmpdir(), "gig-finder-data-test-"));
     const filename = path.join(directory, "test.sqlite");
     try {
-      const first = openDatabase(filename); migrateDatabase(first); new DataStore(first).change(context("Persist task"), (tx) => tx.tasks.create(task)); first.close();
-      const second = openDatabase(filename, { create:false }); migrateDatabase(second); expect(new DataStore(second).tasks.get(task.id)?.title).toBe(task.title); second.close();
+      const first = openDatabase(filename);
+      migrateDatabase(first);
+      const firstStore = new DataStore(first);
+      firstStore.change(context("Persist task"), (tx) => tx.tasks.create(task));
+      firstStore.settings.set("agent_model", "gpt-5.6-luna");
+      first.close();
+
+      const second = openDatabase(filename, { create:false });
+      migrateDatabase(second);
+      const secondStore = new DataStore(second);
+      expect(secondStore.tasks.get(task.id)?.title).toBe(task.title);
+      expect(secondStore.settings.get("agent_model")).toBe("gpt-5.6-luna");
+      second.close();
     } finally { await rm(directory, { recursive:true, force:true }); }
   });
 });
 
 describe("typed CRUD repositories", () => {
+  test("persists application settings independently of entity history", () => {
+    expect(store.settings.get("agent_model")).toBeNull();
+    store.settings.set("agent_model", "gpt-5.6-terra");
+    expect(store.settings.get("agent_model")).toBe("gpt-5.6-terra");
+    expect((database.query("SELECT count(*) count FROM changes").get() as { count: number }).count).toBe(0);
+  });
   test("creates and reads gigs with initial metadata", () => {
     const result = store.change(context("Create gig"), (tx) => tx.gigs.create(gig));
     expect(result.value).toMatchObject({ id:"gig-1", revision:1, isDeleted:false, createdAt:timestamp, updatedAt:timestamp });

--- a/src/entrypoints/web.ts
+++ b/src/entrypoints/web.ts
@@ -11,16 +11,23 @@ import { loadCandidateProfile } from "../agent/profile-loader";
 import { openLocalApplication, resolveGigFinderContext } from "../data/src";
 import { registerDevelopmentTelemetry } from "../observability/devtools";
 import { managedDocumentContentLimit, StagedDocumentService } from "../core/src";
+import {
+  defaultAgentModelId,
+  parseAgentModelId,
+} from "../core/src/application-settings";
 import { LocalDocumentConverter } from "../web/document-conversion";
 import { createDocumentUploadHandler } from "../web/document-upload-handler";
 
 const repoRoot = path.resolve(import.meta.dir, "../..");
 const devToolsEnabled = await registerDevelopmentTelemetry();
 const context = resolveGigFinderContext(repoRoot);
+const defaultAgentModel = parseAgentModelId(
+  process.env.CODEX_AGENT_MODEL ?? defaultAgentModelId,
+);
 const local = openLocalApplication({
   database: context.database,
   artifacts: context.artifacts,
-});
+}, { defaultAgentModel });
 const gigFinder = local.application;
 const port = Number(process.env.API_PORT ?? 3001);
 const positiveInteger = (value: string | undefined, fallback: number) => {
@@ -43,11 +50,10 @@ const uploadHandler = createDocumentUploadHandler(
   stagedDocuments,
   uploadLimits.maxBytes,
 );
-const agentHandler = createAgentHandler(
-  loadCandidateProfile(context.profile),
-  undefined,
+const agentHandler = createAgentHandler({
+  profile: loadCandidateProfile(context.profile),
   logger,
-  {
+  reads: {
     gigs: gigFinder.gigs,
     people: gigFinder.people,
     gigPeople: gigFinder.gigPeople,
@@ -55,10 +61,11 @@ const agentHandler = createAgentHandler(
     meetings: gigFinder.meetings,
     documents: gigFinder.documentReader,
   },
-  gigFinder,
-  context.actor,
-  { contextSearch: gigFinder.contextSearch, stagedDocuments },
-);
+  mutations: gigFinder,
+  actor: context.actor,
+  toolExtensions: { contextSearch: gigFinder.contextSearch, stagedDocuments },
+  selectModel: () => gigFinder.settings.get().agentModel,
+});
 const server = Bun.serve({
   port,
   hostname: "127.0.0.1",

--- a/src/web/agent-handler.test.ts
+++ b/src/web/agent-handler.test.ts
@@ -117,10 +117,10 @@ describe("agent web adapter", () => {
   });
 
   test("serves the POST contract through an injected model", async () => {
-    const handler = createAgentHandler(
-      testCandidateProfile,
-      async () => mockModel("This is a deterministic response."),
-    );
+    const handler = createAgentHandler({
+      profile: testCandidateProfile,
+      modelFactory: async () => mockModel("This is a deterministic response."),
+    });
     const response = await handler(new Request("http://localhost/api/agent/messages", {
       method: "POST",
       headers: { "content-type": "application/json" },
@@ -131,11 +131,33 @@ describe("agent web adapter", () => {
     expect(await response.text()).toContain("This is a deterministic response.");
   });
 
+  test("resolves the selected model for each new request", async () => {
+    const selectedModels: string[] = [];
+    const handler = createAgentHandler({
+      profile: testCandidateProfile,
+      modelFactory: async modelId => {
+        selectedModels.push(modelId);
+        return mockModel();
+      },
+      selectModel: () => "gpt-5.6-terra",
+    });
+    const response = await handler(new Request("http://localhost/api/agent/messages", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ messages: [userMessage("Hello")] }),
+    }));
+    await response.text();
+    expect(selectedModels).toEqual(["gpt-5.6-terra"]);
+  });
+
   test("throws validation errors for the server boundary to log and map", async () => {
     let modelCreated = false;
-    const handler = createAgentHandler(testCandidateProfile, async () => {
-      modelCreated = true;
-      return mockModel();
+    const handler = createAgentHandler({
+      profile: testCandidateProfile,
+      modelFactory: async () => {
+        modelCreated = true;
+        return mockModel();
+      },
     });
     const request = new Request("http://localhost/api/agent/messages", {
       method: "POST",

--- a/src/web/agent-handler.ts
+++ b/src/web/agent-handler.ts
@@ -15,8 +15,24 @@ import {
 } from "../agent/gig-finder-tools";
 import type { GigFinderMutationCapabilities } from "../agent/gig-finder-tools";
 import { logger as defaultLogger } from "../observability/logger";
+import {
+  defaultAgentModelId,
+  type AgentModelId,
+} from "../core/src/application-settings";
 
-type ModelFactory = () => Promise<LanguageModel>;
+type ModelFactory = (modelId: AgentModelId) => Promise<LanguageModel>;
+type ModelSelector = () => AgentModelId;
+
+export interface AgentHandlerOptions {
+  profile: CandidateProfile;
+  modelFactory?: ModelFactory;
+  selectModel?: ModelSelector;
+  logger?: Logger;
+  reads?: GigFinderReadCapabilities;
+  mutations?: GigFinderMutationCapabilities;
+  actor?: string;
+  toolExtensions?: GigFinderToolExtensions;
+}
 
 export const agentLimits = {
   maxMessages: 20,
@@ -91,15 +107,16 @@ export function safeAgentError(error: unknown) {
   return "The GigFinderAgent could not complete that response. Please try again.";
 }
 
-export function createAgentHandler(
-  profile: CandidateProfile,
-  modelFactory: ModelFactory = createCodexLanguageModel,
-  logger: Logger = defaultLogger,
-  reads?: GigFinderReadCapabilities,
-  mutations?: GigFinderMutationCapabilities,
+export function createAgentHandler({
+  profile,
+  modelFactory = createCodexLanguageModel,
+  selectModel = () => defaultAgentModelId,
+  logger = defaultLogger,
+  reads,
+  mutations,
   actor = "GigFinderAgent",
-  toolExtensions?: GigFinderToolExtensions,
-) {
+  toolExtensions,
+}: AgentHandlerOptions) {
   return async (request: Request) => {
     const requestId = request.headers.get("x-request-id") || crypto.randomUUID();
     const requestStartedAt = performance.now();
@@ -122,9 +139,14 @@ export function createAgentHandler(
         err: request.signal.reason,
       }, "Agent request signal aborted");
     }, { once: true });
+    const selectedModel = selectModel();
+    agentLogger.debug({
+      event: "agent.model.selected",
+      modelId: selectedModel,
+    }, "Selected agent model");
     const agent = new GigFinderAgent({
       profile,
-      model: await modelFactory(),
+      model: await modelFactory(selectedModel),
       logger: agentLogger,
       tools: reads
         ? createGigFinderTools(

--- a/src/web/e2e/gig-board.e2e.ts
+++ b/src/web/e2e/gig-board.e2e.ts
@@ -133,6 +133,15 @@ test("session-only GigFinderAgent streams guidance and remains available across 
   await expect(panel).toBeVisible();
   await expect(launcher).toBeHidden();
   await expect(panel).toHaveAttribute("data-layout", "panel");
+  const modelSelector = panel.getByLabel("Agent model");
+  await expect(modelSelector).toHaveValue("gpt-5.6-sol");
+  const modelUpdate = page.waitForResponse(response =>
+    response.url().endsWith("/api/settings/agent-model")
+    && response.request().method() === "PUT");
+  await modelSelector.selectOption("gpt-5.6-terra");
+  expect((await modelUpdate).status()).toBe(200);
+  await page.reload();
+  await expect(panel.getByLabel("Agent model")).toHaveValue("gpt-5.6-terra");
   await expect(panel.getByRole("button", { name: "Dock agent to side" })).toHaveAttribute("aria-pressed", "true");
   await expect(panel.locator(".agent-boundary")).toHaveCount(0);
   const resizeHandle = panel.getByRole("separator", { name: "Resize agent panel" });

--- a/src/web/server.test.ts
+++ b/src/web/server.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { Database } from "bun:sqlite";
+import pino from "pino";
+import { GigFinderApplication } from "../core/src/application";
+import type { ArtifactPort } from "../core/src/ports";
+import {
+  AuditReader,
+  DataStore,
+  migrateDatabase,
+  openDatabase,
+} from "../data/src";
+import { createWebHandler } from "./server";
+
+const artifacts: ArtifactPort = {
+  jobDescription: async () => "",
+  interviewPrep: async () => [],
+  jobDescriptionExists: async () => false,
+  interviewPrepExists: async () => false,
+  verify: async () => ({ ok: true, errors: [], unregistered: [] }),
+};
+const logger = pino({ enabled: false });
+const requestServer = { timeout: () => undefined };
+
+let database: Database;
+let fetchRequest: ReturnType<typeof createWebHandler>;
+
+beforeEach(() => {
+  database = openDatabase(":memory:");
+  migrateDatabase(database);
+  const application = new GigFinderApplication(
+    new DataStore(database),
+    new AuditReader(database),
+    artifacts,
+  );
+  fetchRequest = createWebHandler({
+    gigFinder: application,
+    agentHandler: async () => new Response(null),
+    uploadHandler: async () => new Response(null),
+    discardStagedDocument: () => false,
+    requestLogger: () => logger,
+  });
+});
+
+afterEach(() => database.close());
+
+describe("agent model settings API", () => {
+  test("returns the default and persists a supported selection", async () => {
+    const initial = await fetchRequest(
+      new Request("http://localhost/api/settings/agent-model"),
+      requestServer,
+    );
+    expect(initial.status).toBe(200);
+    expect(await initial.json()).toEqual({ agentModel: "gpt-5.6-sol" });
+
+    const update = await fetchRequest(
+      new Request("http://localhost/api/settings/agent-model", {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ modelId: "gpt-5.6-luna" }),
+      }),
+      requestServer,
+    );
+    expect(update.status).toBe(200);
+    expect(await update.json()).toEqual({ agentModel: "gpt-5.6-luna" });
+
+    const persisted = await fetchRequest(
+      new Request("http://localhost/api/settings/agent-model"),
+      requestServer,
+    );
+    expect(await persisted.json()).toEqual({ agentModel: "gpt-5.6-luna" });
+  });
+
+  test("rejects unsupported values without changing the preference", async () => {
+    const invalid = await fetchRequest(
+      new Request("http://localhost/api/settings/agent-model", {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ modelId: "gpt-unsupported" }),
+      }),
+      requestServer,
+    );
+    expect(invalid.status).toBe(422);
+    expect(await invalid.json()).toEqual({
+      error: "Agent model must be one of: gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna.",
+      code: "domain_validation_failed",
+    });
+
+    const persisted = await fetchRequest(
+      new Request("http://localhost/api/settings/agent-model"),
+      requestServer,
+    );
+    expect(await persisted.json()).toEqual({ agentModel: "gpt-5.6-sol" });
+  });
+});

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -1,6 +1,8 @@
 import type { Logger } from "pino";
 import type { GigFinderApplication } from "../core/src/application";
+import { parseAgentModelId } from "../core/src/application-settings";
 import { toWebError } from "./error-response";
+import { WebRequestError } from "./agent-handler";
 
 const agentIdleTimeoutSeconds = 120;
 const documentUploadTimeoutSeconds = 60;
@@ -16,6 +18,27 @@ export interface WebHandlerDependencies {
 
 interface RequestTimeoutController {
   timeout(request: Request, seconds: number): void;
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+async function updateAgentModel(
+  request: Request,
+  gigFinder: GigFinderApplication,
+) {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch (error) {
+    throw new WebRequestError("Request body must be valid JSON.", 400, {
+      cause: error,
+    });
+  }
+  const modelId = parseAgentModelId(
+    isRecord(body) ? body.modelId : undefined,
+  );
+  return gigFinder.settings.setAgentModel(modelId);
 }
 
 export function createWebHandler({gigFinder,agentHandler,uploadHandler,discardStagedDocument,requestLogger}:WebHandlerDependencies) {
@@ -63,6 +86,12 @@ export function createWebHandler({gigFinder,agentHandler,uploadHandler,discardSt
             ? new Response(null, { status: 204 })
             : json({ error: "Staged document not found" }, 404)
           : json({ error: "Method not allowed" }, 405);
+      } else if (url.pathname === "/api/settings/agent-model") {
+        response = request.method === "GET"
+          ? json(gigFinder.settings.get())
+          : request.method === "PUT"
+            ? json(await updateAgentModel(request, gigFinder))
+            : json({ error: "Method not allowed" }, 405);
       } else if (request.method !== "GET") {
         response = json({ error: "Read-only API" }, 405);
       } else if (url.pathname === "/api/gigs") {

--- a/src/web/src/agent/AgentPanel.tsx
+++ b/src/web/src/agent/AgentPanel.tsx
@@ -14,6 +14,16 @@ import {
   minimumAgentPanelWidth,
   type AgentLayout,
 } from "./agent-workspace";
+import {
+  agentModelCatalog,
+  defaultAgentModelId,
+  isAgentModelId,
+  type AgentModelId,
+} from "../../../core/src/application-settings";
+import {
+  loadApplicationSettings,
+  saveAgentModel,
+} from "../data/settings";
 
 const starterPrompts = [
   "What kinds of roles should I prioritize?",
@@ -153,6 +163,9 @@ export function AgentPanel({
   const [upload, setUpload] = useState<StagedUpload | null>(null);
   const [uploadingFilename, setUploadingFilename] = useState<string | null>(null);
   const [uploadFailure, setUploadFailure] = useState<string | null>(null);
+  const [agentModel, setAgentModel] = useState<AgentModelId>(defaultAgentModelId);
+  const [modelSaving, setModelSaving] = useState(false);
+  const [modelFailure, setModelFailure] = useState<string | null>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const uploadAbortRef = useRef<AbortController | null>(null);
@@ -215,6 +228,45 @@ export function AgentPanel({
     startWidth: number;
   } | null>(null);
   activeRef.current = active;
+
+  useEffect(() => {
+    let mounted = true;
+    void loadApplicationSettings()
+      .then(settings => {
+        if (mounted) setAgentModel(settings.agentModel);
+      })
+      .catch(error => {
+        if (mounted) {
+          setModelFailure(
+            error instanceof Error
+              ? error.message
+              : "The agent model preference could not be loaded.",
+          );
+        }
+      });
+    return () => { mounted = false; };
+  }, []);
+
+  const selectAgentModel = async (nextModel: AgentModelId) => {
+    if (modelSaving || nextModel === agentModel) return;
+    const previousModel = agentModel;
+    setAgentModel(nextModel);
+    setModelFailure(null);
+    setModelSaving(true);
+    try {
+      const settings = await saveAgentModel(nextModel);
+      setAgentModel(settings.agentModel);
+    } catch (error) {
+      setAgentModel(previousModel);
+      setModelFailure(
+        error instanceof Error
+          ? error.message
+          : "The agent model preference could not be saved.",
+      );
+    } finally {
+      setModelSaving(false);
+    }
+  };
 
   useEffect(() => () => {
     document.body.classList.remove("is-resizing-agent");
@@ -340,6 +392,7 @@ export function AgentPanel({
       (!value && !attachedUpload)
       || activeRef.current
       || uploadingRef.current
+      || modelSaving
     ) return;
     const outgoingText = attachedUpload
       ? [value, `Attached staged document: ${attachedUpload.reference}`]
@@ -369,6 +422,7 @@ export function AgentPanel({
   };
 
   const retry = () => {
+    if (modelSaving) return;
     const sequence = sequenceRef.current + 1;
     sequenceRef.current = sequence;
     diagnosticRef.current = {
@@ -472,6 +526,28 @@ export function AgentPanel({
           </div>
         </div>
         <div className="agent-header-actions">
+          <label className="agent-model-control">
+            <span>Model</span>
+            <select
+              aria-label="Agent model"
+              value={agentModel}
+              disabled={modelSaving}
+              aria-busy={modelSaving}
+              onChange={event => {
+                if (isAgentModelId(event.target.value)) {
+                  void selectAgentModel(event.target.value);
+                }
+              }}
+            >
+              {agentModelCatalog.map(model => (
+                <option key={model.id} value={model.id}>
+                  {layout === "full"
+                    ? model.label.replace("GPT-5.6 ", "")
+                    : model.label}
+                </option>
+              ))}
+            </select>
+          </label>
           <div className="agent-layout-controls" role="group" aria-label="Agent layout">
             {layoutChoices.map(choice => (
               <button
@@ -486,6 +562,9 @@ export function AgentPanel({
             ))}
           </div>
           <button className="icon-button" type="button" onClick={onClose} aria-label="Close GigFinder">×</button>
+          {modelFailure && (
+            <span className="agent-model-error" role="alert">{modelFailure}</span>
+          )}
         </div>
       </header>
 
@@ -497,7 +576,7 @@ export function AgentPanel({
             <p>Ask for positioning, role-fit guidance, decision criteria, or a practical next move.</p>
             <div className="agent-starters">
               {starterPrompts.map(prompt => (
-                <button type="button" onClick={() => void submit(prompt)} key={prompt}>{prompt}<span>↗</span></button>
+                <button type="button" disabled={modelSaving} onClick={() => void submit(prompt)} key={prompt}>{prompt}<span>↗</span></button>
               ))}
             </div>
           </div>
@@ -520,7 +599,7 @@ export function AgentPanel({
         <div className="agent-error" role="alert">
           <span>RESPONSE INTERRUPTED</span>
           <p>{interactionFailure || error?.message || "The GigFinderAgent could not complete that response."}</p>
-          <button type="button" onClick={retry}>Retry response</button>
+          <button type="button" onClick={retry} disabled={modelSaving}>Retry response</button>
           <button type="button" onClick={() => {
             clearError();
             setInteractionFailure(null);
@@ -588,7 +667,7 @@ export function AgentPanel({
           placeholder="Ask about fit, positioning, or priorities…"
           rows={3}
           maxLength={8000}
-          disabled={!open || uploadingFilename !== null}
+          disabled={!open || uploadingFilename !== null || modelSaving}
         />
         <div className="agent-composer-footer">
           <span>{active ? "STREAM ACTIVE" : "LIVE DATA ACCESS"}</span>
@@ -605,7 +684,7 @@ export function AgentPanel({
                 });
                 stop();
               }}>Stop <i /></button>
-            : <button className="agent-send" type="submit" disabled={!input.trim() && !upload}>Send <span>↗</span></button>}
+            : <button className="agent-send" type="submit" disabled={modelSaving || (!input.trim() && !upload)}>Send <span>↗</span></button>}
         </div>
       </form>
     </aside>

--- a/src/web/src/data/settings.test.ts
+++ b/src/web/src/data/settings.test.ts
@@ -1,0 +1,11 @@
+import { expect, test } from "bun:test";
+import { parseApplicationSettings } from "./settings";
+
+test("validates the persisted agent model response", () => {
+  expect(parseApplicationSettings({ agentModel: "gpt-5.6-terra" }))
+    .toEqual({ agentModel: "gpt-5.6-terra" });
+  expect(() => parseApplicationSettings({ agentModel: "gpt-unsupported" }))
+    .toThrow("invalid agent model");
+  expect(() => parseApplicationSettings(null))
+    .toThrow("invalid agent model");
+});

--- a/src/web/src/data/settings.ts
+++ b/src/web/src/data/settings.ts
@@ -1,0 +1,41 @@
+import {
+  isAgentModelId,
+  type ApplicationSettings,
+  type AgentModelId,
+} from "../../../core/src/application-settings";
+
+const endpoint = "/api/settings/agent-model";
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+export function parseApplicationSettings(value: unknown): ApplicationSettings {
+  if (!isRecord(value) || !isAgentModelId(value.agentModel)) {
+    throw new Error("The settings service returned an invalid agent model.");
+  }
+  return { agentModel: value.agentModel };
+}
+
+async function responseError(response: Response) {
+  const body: unknown = await response.json().catch(() => null);
+  return isRecord(body) && typeof body.error === "string"
+    ? body.error
+    : `Settings API returned ${response.status}.`;
+}
+
+export async function loadApplicationSettings(): Promise<ApplicationSettings> {
+  const response = await fetch(endpoint, { cache: "no-store" });
+  if (!response.ok) throw new Error(await responseError(response));
+  return parseApplicationSettings(await response.json());
+}
+
+export async function saveAgentModel(
+  modelId: AgentModelId,
+): Promise<ApplicationSettings> {
+  const response = await fetch(endpoint, {
+    method: "PUT",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ modelId }),
+  });
+  if (!response.ok) throw new Error(await responseError(response));
+  return parseApplicationSettings(await response.json());
+}

--- a/src/web/src/styles.css
+++ b/src/web/src/styles.css
@@ -259,9 +259,17 @@ body.is-resizing-agent .dashboard-with-agent { transition: none; }
 .agent-orbit i:nth-child(1) { top: 3px; left: 20px; }
 .agent-orbit i:nth-child(2) { right: 4px; bottom: 9px; }
 .agent-orbit i:nth-child(3) { left: 5px; bottom: 8px; }
-.agent-header-actions { display: flex; align-items: center; gap: 10px; }
+.agent-header-actions { display: grid; grid-template-columns: auto auto; align-items: center; justify-items: end; gap: 6px; }
+.agent-model-control { grid-column: 1 / -1; display: grid; grid-template-columns: auto minmax(0, 1fr); align-items: center; gap: 7px; color: var(--dim); text-transform: uppercase; font: 7px/1 "SFMono-Regular", Consolas, monospace; letter-spacing: .1em; }
+.agent-model-control select { width: 118px; min-height: 27px; padding: 0 22px 0 7px; color: var(--ink); border: 1px solid var(--line); border-radius: 0; background: #f6f7f3; font: 8px/1 "SFMono-Regular", Consolas, monospace; }
+.agent-model-control select:focus-visible { outline: 1px solid var(--amber); outline-offset: 2px; }
+.agent-model-control select:disabled { color: var(--dim); cursor: wait; }
+.agent-model-error { grid-column: 1 / -1; max-width: 150px; color: var(--red); text-align: right; font: 7px/1.35 "SFMono-Regular", Consolas, monospace; }
 .agent-layout-controls { display: flex; align-items: center; padding: 3px; border: 1px solid var(--line); background: #f6f7f3; }
-.agent-panel.is-layout-full .agent-header-actions { flex-direction: column; align-items: stretch; }
+.agent-panel.is-layout-full .agent-header-actions { display: flex; flex-direction: column; align-items: stretch; }
+.agent-panel.is-layout-full .agent-model-control { display: grid; grid-template-columns: 1fr; justify-items: stretch; }
+.agent-panel.is-layout-full .agent-model-control select { width: 100%; }
+.agent-panel.is-layout-full .agent-model-error { max-width: none; text-align: left; }
 .agent-panel.is-layout-full .agent-layout-controls { flex-direction: column; }
 .agent-panel.is-layout-full .agent-layout-controls button,
 .agent-panel.is-layout-full .agent-header-actions > .icon-button { width: 100%; }
@@ -373,6 +381,8 @@ body.is-resizing-agent .dashboard-with-agent { transition: none; }
   .agent-panel.is-layout-full .agent-identity { align-items: center; }
   .agent-panel.is-layout-full .agent-identity h2 { font-size: 16px; line-height: 1; writing-mode: vertical-rl; transform: rotate(180deg); overflow-wrap: normal; }
   .agent-panel.is-layout-full .agent-identity .eyebrow { display: none; }
+  .agent-panel.is-layout-full .agent-model-control span { display: none; }
+  .agent-panel.is-layout-full .agent-model-control select { width: 50px; padding-left: 4px; padding-right: 12px; font-size: 7px; }
   .agent-panel.is-layout-full .agent-messages,
   .agent-panel.is-layout-full .agent-composer { padding-left: 14px; padding-right: 14px; }
   .agent-panel.is-layout-full .agent-error { margin-left: 14px; margin-right: 14px; }


### PR DESCRIPTION
## Summary

- add one shared typed catalog for GPT-5.6 Sol, Terra, and Luna
- persist the selected model through a generic SQLite application-settings repository and migration 0014
- expose validated GET/PUT settings endpoints and resolve the saved model for every new agent request
- add a compact, accessible selector to panel and full-screen layouts
- document the setting and cover defaults, validation, persistence, request selection, reload behavior, and responsive presentation

## Validation

- `bun run check` — 170 tests passed
- `bun run db:check`
- `bun run build`
- `bun run test:e2e` — 5 tests passed

Closes #47
