### PR TITLE
Fix provider-incompatible agent URL schemas

### DIFF
--- a/docs/architecture/tool-contracts.md
+++ b/docs/architecture/tool-contracts.md
@@ -116,6 +116,8 @@ When a provider requires all properties at every object level, the agent adapter
 projects optional core fields as required nullable values and makes nested
 objects complete. This does not make those fields required in the shared domain
 contract or in other clients such as the CLI.
+Provider-unsupported JSON Schema formats are likewise omitted from model-facing
+projections; core still validates the corresponding domain value before write.
 
 Managed-document metadata follows the same entity-owned input-contract pattern.
 Replacing document content remains a distinct versioned command because it is

--- a/src/agent/gig-finder-tools.ts
+++ b/src/agent/gig-finder-tools.ts
@@ -178,8 +178,15 @@ const createGigInputSchema = gigInputSchema.required().safeExtend({
   fit: gigFitSchema.describe("Assessment of how well the Gig fits the candidate."),
   payRange: gigPayRangeSchema.nullable()
     .describe("Expected compensation range, or null when it is not known."),
+  sourceUrl: z.string().trim().min(1).nullable()
+    .describe("Canonical source URL, or null when it is not known."),
 });
-const createPersonInputSchema = personInputSchema.required().safeExtend({relationship:personRelationshipSchema,outreach:personOutreachSchema});
+const createPersonInputSchema = personInputSchema.required().safeExtend({
+  relationship: personRelationshipSchema,
+  outreach: personOutreachSchema,
+  linkedInProfileUrl: z.string().trim().min(1).nullable()
+    .describe("LinkedIn profile URL, or null when it is not known."),
+});
 const createGigPersonRelationshipInputSchema = gigPersonRelationshipInputSchema.required();
 
 const searchGigsAndPeopleInputSchema = z.object({

--- a/src/agent/test/gig-finder-tools.test.ts
+++ b/src/agent/test/gig-finder-tools.test.ts
@@ -1657,6 +1657,22 @@ describe("GigFinderAgent tools", () => {
     }
   });
 
+  test("does not emit provider-unsupported URI formats", () => {
+    const visit = (node: unknown): void => {
+      if (!node || typeof node !== "object") return;
+      if (Array.isArray(node)) {
+        node.forEach(visit);
+        return;
+      }
+      const schema = node as Record<string, unknown>;
+      expect(schema.format).not.toBe("uri");
+      Object.values(schema).forEach(visit);
+    };
+    for (const schema of Object.values(gigFinderToolSchemas)) {
+      visit(z.toJSONSchema(schema));
+    }
+  });
+
   test("keeps create_gig nested values strict while adapting optional domain fields", () => {
     const jsonSchema = z.toJSONSchema(gigFinderToolSchemas.create_gig);
     const properties = jsonSchema.properties as Record<string, Record<string, unknown>>;
@@ -1677,6 +1693,33 @@ describe("GigFinderAgent tools", () => {
       company: "Synthetic Co",
       title: "Engineering Director",
     }).success).toBe(false);
+  });
+
+  test("leaves URL validation at the domain boundary without emitting URI formats", () => {
+    const completeGig = {
+      company: "Synthetic Co",
+      title: "Engineering Director",
+      externalJobId: null,
+      stage: "identified" as const,
+      outcome: "pending" as const,
+      statusSummary: "Identified",
+      lastActivity: "2026-08-05",
+      nextAction: null,
+      fit: { rating: "good" as const, summary: null },
+      payRange: null,
+      sourceUrl: "not a URL",
+      tags: [],
+      location: null,
+      workArrangement: null,
+      postedDate: null,
+      businessUnitTeam: null,
+      recruiterSource: null,
+      bonus: null,
+      equity: null,
+      otherCompensation: null,
+    };
+    expect(gigFinderToolSchemas.create_gig.safeParse(completeGig).success).toBe(true);
+    expect(gigInputSchema.safeParse(completeGig).success).toBe(false);
   });
 
   test("generates a Codex-compatible flat document source schema", () => {

--- a/src/agent/update-tool-schemas.ts
+++ b/src/agent/update-tool-schemas.ts
@@ -24,9 +24,12 @@ function operationListSchema<T extends readonly [string, ...string[]]>(
   clearable: ReadonlySet<T[number]>,
   clearOnly: ReadonlySet<T[number]>,
   domainSchema: z.ZodObject,
+  modelFieldSchemas: Partial<Record<T[number], z.ZodType>> = {},
 ) {
   const schemas=Object.fromEntries(fields.map(field=>[field,schemaAtPath(domainSchema,field)])) as Record<T[number],z.ZodType>;
-  const valueSchemas=fields.filter(field=>!clearOnly.has(field)).map(field=>schemas[field as T[number]]);
+  const valueSchemas=fields.filter(field=>!clearOnly.has(field)).map(field=>
+    modelFieldSchemas[field as T[number]] ?? schemas[field as T[number]],
+  );
   const valueSchema=z.union(valueSchemas as [z.ZodType,z.ZodType,...z.ZodType[]]);
   return z.array(z.object({
     operation: z.enum(["set", "clear"])
@@ -91,6 +94,7 @@ export const gigChangesSchema = operationListSchema(
   gigClearableInputFieldPaths,
   gigClearOnlyInputFieldPaths,
   gigInputSchema,
+  { sourceUrl: z.string().trim().min(1).nullable().describe("Canonical source URL, or null.") },
 );
 
 export const personChangesSchema = operationListSchema(
@@ -98,6 +102,7 @@ export const personChangesSchema = operationListSchema(
   personClearableInputFieldPaths,
   new Set(),
   personInputSchema,
+  { linkedInProfileUrl: z.string().trim().min(1).nullable().describe("LinkedIn profile URL, or null.") },
 );
 
 export const meetingChangesSchema = operationListSchema(


### PR DESCRIPTION
## Summary

- removes provider-unsupported `format: "uri"` from all model-facing URL projections
- retains URL validation in the shared Gig and Person domain schemas
- validates the complete emitted tool registry against this production regression

## Production impact

The live provider currently rejects the entire agent tool registry at `create_gig.sourceUrl`, preventing agent requests before model execution. This mitigation changes only the agent adapter's JSON Schema representation; core and CLI validation remain unchanged.

## Verification

- `bun run check` — 234 tests passed
- `bun run build`

Closes #68
