### PR TITLE
Provide current UTC time to each agent turn

### DIFF
--- a/src/agent/gig-finder-agent.ts
+++ b/src/agent/gig-finder-agent.ts
@@ -3,7 +3,10 @@ import {
   streamText,
   type ModelMessage,
 } from "ai";
-import { buildGigFinderInstructions } from "./system-prompt";
+import {
+  buildCurrentTurnContext,
+  buildGigFinderInstructions,
+} from "./system-prompt";
 import type { GigFinderAgentOptions } from "./types";
 
 function textCharacters(messages: ModelMessage[]) {
@@ -28,6 +31,12 @@ export class GigFinderAgent {
     let wasAborted = false;
     const log = this.options.logger;
     const model = this.options.model;
+    const now = this.options.now?.() ?? new Date();
+    const instructions = `${buildGigFinderInstructions(this.options.profile, {
+      liveRecords: this.options.tools !== undefined,
+      canUpdateRecords: this.options.canUpdateRecords,
+      profileDocuments: this.options.profileDocuments,
+    })}\n\n${buildCurrentTurnContext(now)}`;
     const modelIdentity = typeof model === "string"
       ? { provider: "registry", modelId: model }
       : { provider: model.provider, modelId: model.modelId };
@@ -42,11 +51,7 @@ export class GigFinderAgent {
     log.debug(interaction, "Starting model interaction");
     const result = streamText({
       model,
-      instructions: buildGigFinderInstructions(this.options.profile, {
-        liveRecords: this.options.tools !== undefined,
-        canUpdateRecords: this.options.canUpdateRecords,
-        profileDocuments: this.options.profileDocuments,
-      }),
+      instructions,
       messages,
       tools: this.options.tools,
       stopWhen: isStepCount(5),

--- a/src/agent/system-prompt.ts
+++ b/src/agent/system-prompt.ts
@@ -3,6 +3,13 @@ import type { ProfileDocumentContext } from "../core/documents";
 
 export const gigFinderAgentPolicyVersion = "1.0.0";
 
+export function buildCurrentTurnContext(now: Date) {
+  if (!Number.isFinite(now.getTime())) {
+    throw new Error("Agent turn time must be a valid date.");
+  }
+  return `Current UTC time: ${now.toISOString()}`;
+}
+
 export const genericGigFinderAgentSystemPrompt = `
 You are GigFinderAgent, a practical advisor for people conducting a job search.
 

--- a/src/agent/test/gig-finder-agent.test.ts
+++ b/src/agent/test/gig-finder-agent.test.ts
@@ -20,6 +20,7 @@ import {
 import { validateStrictToolJsonSchema } from "./strict-tool-schema";
 import { testCandidateProfile } from "./fixtures";
 import {
+  buildCurrentTurnContext,
   buildGigFinderInstructions,
   genericGigFinderAgentSystemPrompt,
   gigFinderDocumentInstructions,
@@ -161,6 +162,15 @@ function mockModel(answer = "Prioritize roles with matching leadership scope.") 
 }
 
 describe("GigFinderAgent instructions", () => {
+  test("formats trusted current UTC turn context", () => {
+    expect(buildCurrentTurnContext(new Date("2026-08-05T23:15:00.000Z"))).toBe(
+      "Current UTC time: 2026-08-05T23:15:00.000Z",
+    );
+    expect(() => buildCurrentTurnContext(new Date(Number.NaN))).toThrow(
+      "Agent turn time must be a valid date.",
+    );
+  });
+
   test("keeps the generic policy independent of a particular search", () => {
     expect(genericGigFinderAgentSystemPrompt).toContain("You are GigFinderAgent");
     expect(genericGigFinderAgentSystemPrompt).not.toContain("Jordan");
@@ -258,6 +268,35 @@ describe("GigFinderAgent instructions", () => {
 });
 
 describe("agent streaming", () => {
+  test("injects a fresh UTC timestamp on every turn without changing messages", async () => {
+    const model = mockModel();
+    const times = [
+      new Date("2026-08-05T23:59:59.000Z"),
+      new Date("2026-08-06T00:00:01.000Z"),
+    ];
+    let turn = 0;
+    const agent = new GigFinderAgent({
+      profile: testCandidateProfile,
+      model,
+      logger,
+      now: () => times[turn++]!,
+    });
+    const messages = [userMessage("What did I do yesterday?")];
+    const original = structuredClone(messages);
+
+    await agent.respond(messages).text;
+    await agent.respond(messages).text;
+
+    expect(JSON.stringify(model.doStreamCalls[0]?.prompt)).toContain(
+      "Current UTC time: 2026-08-05T23:59:59.000Z",
+    );
+    expect(JSON.stringify(model.doStreamCalls[1]?.prompt)).toContain(
+      "Current UTC time: 2026-08-06T00:00:01.000Z",
+    );
+    expect(messages).toEqual(original);
+    expect(JSON.stringify(messages)).not.toContain("Current UTC time");
+  });
+
   test("sends the complete strict tool registry through the AI SDK model boundary", async () => {
     const model = mockModel("Tool registry accepted.");
     const mutations: GigFinderMutationCapabilities = {

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -34,4 +34,5 @@ export interface GigFinderAgentOptions {
   tools?: import("./gig-finder-tools").GigFinderTools;
   canUpdateRecords?: boolean;
   profileDocuments?: ProfileDocumentContext[];
+  now?: () => Date;
 }


### PR DESCRIPTION
Closes #72

## What changed

- injects a freshly computed current UTC timestamp into every agent turn
- keeps the timestamp out of persisted conversation messages
- adds an injectable clock and invalid-date guard
- covers per-turn freshness and UTC date-boundary behavior

## Impact

The model receives the current UTC time on each request, allowing it to interpret relative dates from current context without additional prompt instructions.

## Validation

- `bun run check` — 236 tests passed
- `bun run build`
- `git diff --check`
