### PR TITLE
Restore ADR 0009 personal-data boundary

### DIFF
--- a/docs/architecture/decisions/0009-keep-personal-data-out-of-source-control.md
+++ b/docs/architecture/decisions/0009-keep-personal-data-out-of-source-control.md
@@ -1,0 +1,45 @@
+# ADR 0009: Keep personal data out of source control
+
+**Status:** Accepted
+**Date:** 2026-08-06
+
+## Context
+
+GigFinder operates on private job-search data, including people, employers,
+positions, communications, documents, and activity history. Application code,
+tests, examples, migrations, logs, and generated artifacts can unintentionally
+copy that data into Git history, where deletion is difficult and public release
+may expose it permanently.
+
+## Decision
+
+Git-tracked files contain no data sourced from a user's actual job search.
+Prohibited data includes real or pseudonymized people, companies, positions,
+applications, interactions, event identifiers or summaries, documents,
+messages, profile content, URLs, database records, logs, credentials, and
+derived combinations that could identify those records.
+
+This boundary applies to source code, configuration defaults, migrations,
+fixtures, tests, examples, snapshots, documentation, generated files, build
+contexts, and release artifacts. Replacing a name with an internal identifier
+does not make a production record suitable for source control.
+
+Tests and examples use intentionally synthetic fixtures that are not adapted
+from private records. Generic domain language such as “Example Company” or
+“Director of Engineering” is allowed when it does not reproduce an actual
+record.
+
+Private operational data lives only in ignored local context directories or
+external production state. One-time rollout inputs and generated commands stay
+ignored, are validated before use, and are never copied into committed
+migrations. Before committing data-related changes, the staged diff is checked
+for private values and unintended tracked files.
+
+## Consequences
+
+- The public repository and its history remain free of personal job-search
+  data.
+- Migrations and tests must express generic behavior with synthetic fixtures.
+- One-time data conversion may require ignored local artifacts and an
+  operator-run validation step.
+- Private data cannot be used as a convenient committed regression fixture.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -75,6 +75,7 @@ seam and defaults to the subscription provider.
 - [ADR 0006: Make database document state authoritative](decisions/0006-authoritative-document-state.md) treats filesystem content as imports or repairable projections.
 - [ADR 0007: Deploy Docker images with external state and verified rollback](decisions/0007-immutable-production-deployment.md) defines the production release and recovery model.
 - [ADR 0008: Adapt domain capabilities to strict agent tools](decisions/0008-agent-tool-contracts.md) defines tool patches, schema strictness, and generated contract documentation.
+- [ADR 0009: Keep personal data out of source control](decisions/0009-keep-personal-data-out-of-source-control.md) prohibits private job-search records in tracked files and requires synthetic fixtures.
 
 Runtime settings are documented in [Configuration](configuration.md). Production
 layout and procedures are documented in the [Deployment runbook](deployment-runbook.md).


### PR DESCRIPTION
## Summary

- restore accepted ADR 0009 defining the personal-data source-control boundary
- require intentionally synthetic fixtures rather than private job-search records
- link the recovered decision from the architecture overview

## Verification

- bun run check (222 tests)
- bun run build
- staged diff reviewed for private values and unintended files

Closes #91