### PR TITLE
Increase the agent step budget for complex tool-assisted work

### DIFF
--- a/src/agent/gig-finder-agent.ts
+++ b/src/agent/gig-finder-agent.ts
@@ -34,6 +34,8 @@ type EndLogEvent = Pick<StepEndLogEvent, "usage" | "finishReason"> & {
   steps: readonly { text: string; toolCalls: readonly unknown[] }[];
 };
 
+export const defaultAgentStepLimit = 20;
+
 function textCharacters(messages: ModelMessage[]) {
   return messages.reduce((total, message) => {
     if (typeof message.content === "string") return total + message.content.length;
@@ -48,6 +50,7 @@ export class GigFinderAgent {
 
   respond(messages: ModelMessage[], signal?: AbortSignal) {
     const startedAt = performance.now();
+    const effectiveMaxSteps = this.options.maxSteps ?? defaultAgentStepLimit;
     let activeStep: {
       callId: string;
       stepNumber: number;
@@ -78,7 +81,7 @@ export class GigFinderAgent {
       instructions,
       messages,
       tools: this.options.tools,
-      stopWhen: isStepCount(this.options.maxSteps ?? 5),
+      stopWhen: isStepCount(effectiveMaxSteps),
       maxOutputTokens: this.options.maxOutputTokens,
       abortSignal: signal,
       maxRetries: 1,
@@ -155,11 +158,19 @@ export class GigFinderAgent {
         activeStep = null;
       },
       onEnd: ({ usage, finishReason, steps }: EndLogEvent) => {
-        const outcome = wasAborted ? "aborted" : "completed";
-        log.info({
+        const stepLimitExhausted = !wasAborted
+          && finishReason === "tool-calls"
+          && steps.length === effectiveMaxSteps;
+        const outcome = wasAborted
+          ? "aborted"
+          : stepLimitExhausted
+            ? "step_limit_exhausted"
+            : "completed";
+        const entry = {
           ...interaction,
           event: "model.interaction.finished",
           outcome,
+          configuredStepLimit: effectiveMaxSteps,
           latencyMs: Math.round(performance.now() - startedAt),
           finishReason,
           stepCount: steps.length,
@@ -178,7 +189,12 @@ export class GigFinderAgent {
             cachedInputTokens: usage.inputTokenDetails.cacheReadTokens,
             reasoningTokens: usage.outputTokenDetails.reasoningTokens,
           },
-        }, `${outcome === "aborted" ? "Aborted" : "Completed"} model interaction`);
+        };
+        if (stepLimitExhausted) {
+          log.warn(entry, "Model interaction reached the configured step limit");
+        } else {
+          log.info(entry, `${outcome === "aborted" ? "Aborted" : "Completed"} model interaction`);
+        }
       },
       onAbort: ({ steps }: { steps: readonly unknown[] }) => {
         wasAborted = true;

--- a/src/agent/test/gig-finder-agent.test.ts
+++ b/src/agent/test/gig-finder-agent.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { simulateReadableStream, type ModelMessage } from "ai";
+import { simulateReadableStream, tool, type ModelMessage } from "ai";
 import { MockLanguageModelV4 } from "ai/test";
 import type { Logger } from "pino";
+import { z } from "zod";
 import type {
   ChangeContext,
   GigRecord,
@@ -11,6 +12,7 @@ import type {
 } from "../../core";
 import { StagedDocumentService } from "../../core";
 import { GigFinderAgent } from "../gig-finder-agent";
+import type { GigFinderAgentOptions } from "../types";
 import {
   createGigFinderTools as createCompleteGigFinderTools,
   gigFinderToolSchemas,
@@ -183,6 +185,52 @@ function mockModel(answer = "Prioritize roles with matching leadership scope.") 
     }),
   });
 }
+
+function toolCallStep(index: number) {
+  return {
+    stream: simulateReadableStream({
+      chunks: [
+        { type: "stream-start" as const, warnings: [] },
+        {
+          type: "tool-call" as const,
+          toolCallId: `tool-call-${index}`,
+          toolName: "continue_work",
+          input: JSON.stringify({ step: index }),
+        },
+        {
+          type: "finish" as const,
+          finishReason: { unified: "tool-calls" as const, raw: undefined },
+          usage,
+        },
+      ],
+    }),
+  };
+}
+
+const finalAnswerStep = {
+  stream: simulateReadableStream({
+    chunks: [
+      { type: "stream-start" as const, warnings: [] },
+      { type: "text-start" as const, id: "text-final" },
+      { type: "text-delta" as const, id: "text-final", delta: "All requested work finished." },
+      { type: "text-end" as const, id: "text-final" },
+      {
+        type: "finish" as const,
+        finishReason: { unified: "stop" as const, raw: undefined },
+        usage,
+      },
+    ],
+  }),
+};
+
+const continuingTool = tool({
+  description: "Advances a synthetic multi-step workflow.",
+  inputSchema: z.object({ step: z.number() }),
+  execute: async ({ step }) => ({ completedStep: step }),
+});
+const syntheticTools = {
+  continue_work: continuingTool,
+} as unknown as NonNullable<GigFinderAgentOptions["tools"]>;
 
 describe("GigFinderAgent instructions", () => {
   test("formats trusted current UTC turn context", () => {
@@ -420,6 +468,77 @@ describe("agent streaming", () => {
       },
     });
     expect(completion?.data.latencyMs).toBeNumber();
+  });
+
+  test("allows a workflow longer than five steps to finish with the production default", async () => {
+    const model = new MockLanguageModelV4({
+      doStream: [
+        toolCallStep(1),
+        toolCallStep(2),
+        toolCallStep(3),
+        toolCallStep(4),
+        toolCallStep(5),
+        toolCallStep(6),
+        finalAnswerStep,
+      ],
+    });
+    const agent = new GigFinderAgent({
+      profile: testCandidateProfile,
+      model,
+      logger,
+      tools: syntheticTools,
+    });
+
+    const result = agent.respond([userMessage("Complete the synthetic workflow.")]);
+
+    expect(await result.text).toBe("All requested work finished.");
+    expect(model.doStreamCalls).toHaveLength(7);
+    expect((await result.steps)).toHaveLength(7);
+  });
+
+  test("logs step-limit exhaustion distinctly and retains successful tool results", async () => {
+    const logEntries: Array<{ level: string; data: Record<string, unknown> }> = [];
+    const testLogger = {
+      debug: (data: Record<string, unknown>) => logEntries.push({ level: "debug", data }),
+      info: (data: Record<string, unknown>) => logEntries.push({ level: "info", data }),
+      warn: (data: Record<string, unknown>) => logEntries.push({ level: "warn", data }),
+      error: (data: Record<string, unknown>) => logEntries.push({ level: "error", data }),
+    } as unknown as Logger;
+    const model = new MockLanguageModelV4({
+      doStream: [toolCallStep(1), toolCallStep(2)],
+    });
+    const agent = new GigFinderAgent({
+      profile: testCandidateProfile,
+      model,
+      logger: testLogger,
+      tools: syntheticTools,
+      maxSteps: 2,
+    });
+
+    const result = agent.respond([userMessage("Keep working beyond the limit.")]);
+    const steps = await result.steps;
+
+    expect(steps).toHaveLength(2);
+    expect(steps[0]?.toolResults[0]).toMatchObject({
+      toolName: "continue_work",
+      output: { completedStep: 1 },
+    });
+    expect(logEntries.find(entry => entry.data.event === "model.interaction.finished"))
+      .toMatchObject({
+        level: "warn",
+        data: {
+          outcome: "step_limit_exhausted",
+          configuredStepLimit: 2,
+          stepCount: 2,
+          toolCallCount: 2,
+          finishReason: "tool-calls",
+          usage: {
+            inputTokens: 20,
+            outputTokens: 16,
+            totalTokens: 36,
+          },
+        },
+      });
   });
 
   test("executes an interaction read tool and streams the model's final answer", async () => {

--- a/src/web/client/agent/AgentPanel.tsx
+++ b/src/web/client/agent/AgentPanel.tsx
@@ -43,6 +43,33 @@ const starterPrompts = [
   "Which role categories are poor fits?",
 ];
 
+const genericInterruptedResponseWarning =
+  "GigFinderAgent's response was interrupted before it completed. Please retry.";
+const stepLimitExhaustedWarning =
+  "Processing stopped before all requested work finished. Already completed actions were retained.";
+
+export function agentInteractionWarning({
+  finishReason,
+  isAbort,
+  isDisconnect,
+  isError,
+  deliveredTextCharacters,
+}: {
+  finishReason?: string;
+  isAbort: boolean;
+  isDisconnect: boolean;
+  isError: boolean;
+  deliveredTextCharacters: number;
+}) {
+  if (!isAbort && !isDisconnect && !isError && finishReason === "tool-calls") {
+    return stepLimitExhaustedWarning;
+  }
+  if (!isAbort && (isDisconnect || isError || deliveredTextCharacters === 0)) {
+    return genericInterruptedResponseWarning;
+  }
+  return null;
+}
+
 function messageText(parts: UIMessage["parts"]) {
   return parts.filter(part => part.type === "text").map(part => part.text ?? "").join("");
 }
@@ -322,37 +349,42 @@ export function AgentPanel({
     messages: initialMessages,
     transport,
     throttle: 30,
-    onFinish: ({ message, isAbort, isDisconnect, isError }) => {
+    onFinish: ({ message, isAbort, isDisconnect, isError, finishReason }) => {
       const deliveredTextCharacters = messageText(message.parts).length;
       if (hasSuccessfulMutation(message.parts)) onDataChanged?.();
       const savedReferences = savedUploadReferences(message.parts);
-      const completed = !isAbort
+      const normallyCompleted = !isAbort
         && !isDisconnect
         && !isError
         && deliveredTextCharacters > 0;
-      if (completed) {
+      const stepLimitExhausted = !isAbort
+        && !isDisconnect
+        && !isError
+        && finishReason === "tool-calls";
+      const retained = normallyCompleted || stepLimitExhausted;
+      if (retained) {
         for (const reference of savedReferences) {
           void discardStagedDocument(reference).catch(() => undefined);
         }
       }
-      if (completed && savedReferences.length > 0) {
+      if (retained && savedReferences.length > 0) {
         setUpload(current => current && savedReferences.includes(current.reference)
           ? null
           : current);
       }
-      if (completed) {
+      if (retained) {
         void loadConversations().then(setConversations).catch(() => undefined);
       }
-      if (!isAbort && (isDisconnect || isError || deliveredTextCharacters === 0)) {
-        setInteractionFailure(
-          "GigFinderAgent's response was interrupted before it completed. Please retry.",
-        );
-      }
+      setInteractionFailure(agentInteractionWarning({
+        finishReason,
+        isAbort,
+        isDisconnect,
+        isError,
+        deliveredTextCharacters,
+      }));
     },
     onError: () => {
-      setInteractionFailure(
-        "GigFinderAgent's response was interrupted before it completed. Please retry.",
-      );
+      setInteractionFailure(genericInterruptedResponseWarning);
     },
   });
   const previousStatusRef = useRef(status);
@@ -361,6 +393,9 @@ export function AgentPanel({
   const latestAssistantParts = status === "streaming" && latestMessage?.role === "assistant"
     ? latestMessage.parts
     : undefined;
+  const stepLimitReached = !error
+    && !conversationFailure
+    && interactionFailure === stepLimitExhaustedWarning;
   const activity = currentAgentActivity(status, latestAssistantParts);
   const activeRef = useRef(active);
   const resizeRef = useRef<{
@@ -804,9 +839,11 @@ export function AgentPanel({
 
       {(error || interactionFailure || conversationFailure) && (
         <div className="agent-error" role="alert">
-          <span>RESPONSE INTERRUPTED</span>
+          <span>{stepLimitReached ? "PROCESSING LIMIT REACHED" : "RESPONSE INTERRUPTED"}</span>
           <p>{conversationFailure || interactionFailure || (error ? "The GigFinderAgent could not complete that response. Please retry." : "The GigFinderAgent could not complete that response.")}</p>
-          <button type="button" onClick={retry} disabled={modelSaving}>Retry response</button>
+          {!stepLimitReached && (
+            <button type="button" onClick={retry} disabled={modelSaving}>Retry response</button>
+          )}
           <button type="button" onClick={() => {
             clearError();
             setInteractionFailure(null);

--- a/src/web/e2e/gig-board.e2e.ts
+++ b/src/web/e2e/gig-board.e2e.ts
@@ -423,6 +423,42 @@ test("GigFinderAgent surfaces and retries an interrupted empty response", async 
   expect(attempts).toBe(2);
 });
 
+test("GigFinderAgent warns when the step limit retains completed actions", async ({ page }) => {
+  await page.route("**/api/agent/messages", async route => {
+    await route.fulfill({
+      status: 200,
+      headers: {
+        "content-type": "text/event-stream",
+        "x-vercel-ai-ui-message-stream": "v1",
+      },
+      body: [
+        'data: {"type":"start","messageId":"assistant-step-limit"}',
+        'data: {"type":"start-step"}',
+        'data: {"type":"tool-input-start","toolCallId":"call-1","toolName":"update_gig"}',
+        'data: {"type":"tool-input-delta","toolCallId":"call-1","inputTextDelta":"{\\"id\\":\\"gig-1\\"}"}',
+        'data: {"type":"tool-input-available","toolCallId":"call-1","toolName":"update_gig","input":{"id":"gig-1"}}',
+        'data: {"type":"tool-output-available","toolCallId":"call-1","output":{"status":"ok","changeId":"agent-tool:call-1"}}',
+        'data: {"type":"finish-step"}',
+        'data: {"type":"finish","finishReason":"tool-calls"}',
+        "data: [DONE]",
+        "",
+      ].join("\n\n"),
+    });
+  });
+
+  await page.goto("/");
+  const panel = page.getByRole("complementary", { name: "GigFinder" });
+  await panel.getByLabel("Message GigFinderAgent").fill("Update several records");
+  await panel.getByRole("button", { name: /Send/ }).click();
+  const alert = panel.getByRole("alert");
+  await expect(alert).toContainText("PROCESSING LIMIT REACHED");
+  await expect(alert).toContainText("Processing stopped before all requested work finished");
+  await expect(alert).toContainText("Already completed actions were retained");
+  await expect(alert).not.toContainText("response was interrupted");
+  await expect(alert.getByRole("button", { name: "Retry response" })).toHaveCount(0);
+  await expect(panel.getByText("Updating gig complete")).toBeVisible();
+});
+
 test("document upload stages without the agent and attaches to the next message", async ({ page }) => {
   const stagedReference = "staged-document:11111111-1111-4111-8111-111111111111";
   let agentRequests = 0;

--- a/src/web/test/client/agent/AgentPanel.test.ts
+++ b/src/web/test/client/agent/AgentPanel.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import type { UIMessage } from "ai";
 import {
+  agentInteractionWarning,
   hasSavedUpload,
   hasSuccessfulMutation,
   documentActions,
@@ -22,6 +23,34 @@ import {
 } from "../../../client/agent/agent-activity";
 
 describe("agent activity presentation", () => {
+  test("selects distinct warnings for step exhaustion and interruption", () => {
+    expect(agentInteractionWarning({
+      finishReason: "tool-calls",
+      isAbort: false,
+      isDisconnect: false,
+      isError: false,
+      deliveredTextCharacters: 0,
+    })).toBe(
+      "Processing stopped before all requested work finished. Already completed actions were retained.",
+    );
+    expect(agentInteractionWarning({
+      finishReason: "stop",
+      isAbort: false,
+      isDisconnect: false,
+      isError: false,
+      deliveredTextCharacters: 24,
+    })).toBeNull();
+    expect(agentInteractionWarning({
+      finishReason: undefined,
+      isAbort: false,
+      isDisconnect: true,
+      isError: false,
+      deliveredTextCharacters: 0,
+    })).toBe(
+      "GigFinderAgent's response was interrupted before it completed. Please retry.",
+    );
+  });
+
   test("maps every current tool to a friendly label", () => {
     expect(Object.keys(agentToolLabels).sort()).toEqual([
       "create_document", "create_gig", "create_gig_person_relationship",


### PR DESCRIPTION
## Summary

- raise the production agent loop ceiling from 5 to an explicit 20 steps while preserving `maxSteps` overrides
- classify final-step tool calls at the configured ceiling as `step_limit_exhausted` with bounded lifecycle telemetry
- show a distinct accessible processing-limit warning while retaining successful tool actions and avoiding a potentially duplicative retry
- add focused agent, UI, and browser regression coverage for long workflows and exhaustion

The groomed issue proposed updating `docs/product/overview.md`; that documentation edit was intentionally omitted at the user's explicit direction. No product or architecture documentation was changed.

Closes #83

## Validation

- `bun run check` - passed (232 tests)
- `bun run build` - passed
- `bun run test:e2e` - passed (9 tests)
- independent code review - one P2 UI distinction finding fixed before commit; re-review found no remaining actionable findings

## Smoke evidence

Developer:

- Exact HEAD: `a1de8e4c86981ce1bb971b42cb0b663c56d5ff43`
- `bun run smoke:deterministic`: passed, 5,796 ms; 27 tools, 57 registry validations, restart and hydration passed
- `bun run smoke:live`: passed, 9,934 ms; normal response, no tools called, 90,000 ms timeout boundary

Independent reviewer:

- Exact reviewed HEAD: `a1de8e4c86981ce1bb971b42cb0b663c56d5ff43`
- `bun run smoke:deterministic`: `{"status":"passed","mode":"deterministic","revision":"a1de8e4c86981ce1bb971b42cb0b663c56d5ff43","tools":27,"registryValidations":57,"restart":"passed","hydration":"passed","durationMs":6107}`
- `bun run smoke:live`: `{"status":"passed","mode":"live","revision":"a1de8e4c86981ce1bb971b42cb0b663c56d5ff43","outcome":"normal-response","readOnlyTools":[],"timeoutMs":90000,"durationMs":8630}`

Any commit after a recorded run invalidates that run. Fixes require both smoke
commands and independent review to run again against the new exact HEAD.
