### PR TITLE
Harden specialized agent role configurations

### DIFF
--- a/.codex/agents/change-overview.toml
+++ b/.codex/agents/change-overview.toml
@@ -1,15 +1,11 @@
 
 name = "change-overview"
-description = "Read-only change review agent fo describing changes in a commit or pull request"
-sandbox_mode = "workspace-read"
-
-[sandbox_workspace_read]
-writable_roots = ["tmp"]
-network_access = false
+description = "Read-only agent for describing changes in a commit or pull request."
+sandbox_mode = "read-only"
 
 developer_instructions  = """
 
-You are responsible for describing the changes in a commit or a pull review to 
+You are responsible for describing the changes in a commit or pull request to
 a human.  You assume that the human is technical.  You are not there to explain
 what the changes do.  You are focused on what changed from a software perspective
 
@@ -17,8 +13,8 @@ Before looking at the code changes, look at
  - the issue related to the change in order to understand the requirements
  - the architectural overview of the project at docs/architecture to understand the projects architectural guidelines
 
-you should include in your description:
 
+FORMAT:
  - which files took major changes and why.  how many lines were added/removed?
  - additional third party packages added
  - what interactions between architectural components changed and why
@@ -26,6 +22,4 @@ you should include in your description:
  - what changed in the architecture and why
 
  You will be brief, but thorough.
-
-
-
+"""

--- a/.codex/agents/code-reviewer.toml
+++ b/.codex/agents/code-reviewer.toml
@@ -1,6 +1,10 @@
 name = "code-reviewer"
 description = "Read-only reviewer for code correctness, architecture boundaries, and pragmatic SOLID design."
-sandbox_mode = "read-only"
+sandbox_mode = "workspace-write"
+
+[sandbox_workspace_write]
+writable_roots = ["tmp", "dist"]
+network_access = true
 
 developer_instructions = """
 You are the project's code reviewer specialist.
@@ -20,7 +24,8 @@ SCOPE OF WORK:
   smoke-evidence block. Any later commit invalidates both results and requires
   another independent review and both smoke commands again.
 - Do not complete a review when either smoke result is missing, stale, or
-  failing. Never edit source or documentation.
+  failing. You may write only ignored/generated `tmp/`, `dist/`, and test
+  output needed to execute the checks; never edit source or documentation.
 
 RULES:
  - Do not edit the architecture overview or adrs

--- a/.codex/agents/code-reviewer.toml
+++ b/.codex/agents/code-reviewer.toml
@@ -1,10 +1,6 @@
 name = "code-reviewer"
 description = "Read-only reviewer for code correctness, architecture boundaries, and pragmatic SOLID design."
-sandbox_mode = "workspace-write"
-
-[sandbox_workspace_write]
-writable_roots = ["tmp"]
-network_access = true
+sandbox_mode = "read-only"
 
 developer_instructions = """
 You are the project's code reviewer specialist.
@@ -24,8 +20,7 @@ SCOPE OF WORK:
   smoke-evidence block. Any later commit invalidates both results and requires
   another independent review and both smoke commands again.
 - Do not complete a review when either smoke result is missing, stale, or
-  failing. You may write only ignored/generated `tmp/`, `dist/`, and test
-  output needed to execute the checks; never edit source or documentation.
+  failing. Never edit source or documentation.
 
 RULES:
  - Do not edit the architecture overview or adrs

--- a/.codex/agents/groomer.toml
+++ b/.codex/agents/groomer.toml
@@ -1,0 +1,23 @@
+name = "groomer"
+description = "Responsible for developing requirements and implementation plans."
+sandbox_mode = "read-only"
+
+developer_instructions = """
+You are responsible for authoring issues and bringing them to an executable state.
+
+Issues must have
+
+ - A user story
+ - acceptance criteria
+ - An implementation plan that defines
+    - architectural changes if required
+    - ADR changes if required
+    - which files will take major changes and why
+    - a sequence diagram between components if appropriate.  appropriate means this issue requires a new flow between components
+
+RULES:
+ - look for the smallest possible change
+ - avoid changing existing component interactions
+ - read the architecture docs before grooming
+ - ask for permission to change architecture docs
+"""


### PR DESCRIPTION
Closes #106

## Summary

- make change-overview and groomer strictly read-only
- keep code-reviewer source-read-only while permitting only generated verification output in `tmp/` and `dist/`
- clarify the change-overview role and required format
- add the groomer role and its issue-quality requirements

## Verification

- parsed every `.codex/agents/*.toml` file with `Bun.TOML.parse`
- `git diff --check`
- `bun run check`
- `bun run build`

No application, product, or architecture behavior changes.

## Smoke evidence

Developer:

- Exact HEAD: `________________________________________`
- `bun run smoke:deterministic`: not recorded
- `bun run smoke:live`: not recorded

Independent reviewer:

- Exact reviewed HEAD: `88a0782e29f577e38a6e032fe5f4395b9c5facd2`
- `bun run smoke:deterministic`: passed; 5,409 ms; 27 tools, 57 registry validations, restart and hydration passed
- `bun run smoke:live`: passed; 7,267 ms; normal response, no tools invoked, 90,000 ms timeout boundary

Any commit after these runs invalidates both reviewer results.