### PR TITLE
Keep chat controls visible in constrained viewports

### DIFF
--- a/src/web/client/styles.css
+++ b/src/web/client/styles.css
@@ -228,7 +228,7 @@ h1, h2, h3, p { margin-top: 0; }
 .agent-launcher-signal { position: relative; width: 28px; height: 28px; display: grid; place-items: center; border: 1px solid rgba(154,91,21,.35); border-radius: 50%; }
 .agent-launcher-signal::before { content: ""; width: 12px; height: 12px; border: 1px solid var(--amber); border-radius: 50%; }
 .agent-launcher-signal i { position: absolute; width: 4px; height: 4px; border-radius: 50%; background: var(--amber); box-shadow: 0 0 11px rgba(154,91,21,.45); }
-.agent-panel { position: fixed; z-index: 30; display: grid; grid-template-rows: auto 1fr auto auto; color: var(--ink); background: radial-gradient(circle at 100% 0%, rgba(154,91,21,.05), transparent 34%), var(--panel); box-shadow: -20px 0 70px rgba(45,58,52,.18); visibility: hidden; opacity: 0; transition: transform .28s ease, opacity .2s ease, visibility 0s linear .28s; }
+.agent-panel { position: fixed; z-index: 30; display: grid; grid-template-columns: minmax(0, 1fr); grid-template-rows: auto minmax(0, 1fr) auto auto; max-height: 100dvh; overflow: hidden; color: var(--ink); background: radial-gradient(circle at 100% 0%, rgba(154,91,21,.05), transparent 34%), var(--panel); box-shadow: -20px 0 70px rgba(45,58,52,.18); visibility: hidden; opacity: 0; transition: transform .28s ease, opacity .2s ease, visibility 0s linear .28s; }
 .agent-panel.is-layout-panel { top: 0; right: 0; width: var(--agent-panel-width, 450px); height: 100dvh; border-left: 1px solid rgba(154,91,21,.25); transform: translateX(102%); }
 .agent-panel.is-layout-full { inset: 0; width: 100vw; height: 100dvh; transform: scale(.985); }
 .agent-panel.is-layout-full { --agent-rail-width: 176px; grid-template-columns: var(--agent-rail-width) minmax(0, 1fr); grid-template-rows: minmax(0, 1fr) auto auto; }
@@ -239,14 +239,16 @@ h1, h2, h3, p { margin-top: 0; }
 .agent-resize-handle:focus-visible { outline: 0; }
 body.is-resizing-agent { cursor: ew-resize; user-select: none; }
 body.is-resizing-agent .dashboard-with-agent { transition: none; }
-.agent-panel-header { min-height: 92px; padding: 18px 22px; display: flex; justify-content: space-between; align-items: center; gap: 18px; border-bottom: 1px solid var(--line); }
+.agent-panel-header { min-width: 0; min-height: 92px; padding: 18px 22px; display: flex; justify-content: space-between; align-items: center; gap: 18px; border-bottom: 1px solid var(--line); }
+.agent-panel.is-layout-panel .agent-panel-header { padding-left: 14px; padding-right: 14px; gap: 10px; }
 .agent-panel.is-layout-full .agent-panel-header { grid-column: 1; grid-row: 1 / -1; min-height: 0; padding: 20px 16px; flex-direction: column; align-items: stretch; border-right: 1px solid var(--line); border-bottom: 0; background: rgba(246,247,243,.82); }
 .agent-panel.is-layout-full .agent-messages,
 .agent-panel.is-layout-full .agent-composer { grid-column: 2; padding-left: max(22px, calc((100vw - 1096px) / 2)); padding-right: max(22px, calc((100vw - 1096px) / 2)); }
 .agent-panel.is-layout-full .agent-messages { grid-row: 1; }
 .agent-panel.is-layout-full .agent-error { grid-column: 2; grid-row: 2; margin-left: max(22px, calc((100vw - 1096px) / 2)); margin-right: max(22px, calc((100vw - 1096px) / 2)); }
 .agent-panel.is-layout-full .agent-composer { grid-row: 3; }
-.agent-identity { display: flex; align-items: center; gap: 15px; }
+.agent-identity { min-width: 0; display: flex; align-items: center; gap: 15px; }
+.agent-identity > div { min-width: 0; }
 .agent-identity h2 { margin: 0; color: var(--ink); font: 400 25px/1 Baskerville, "Iowan Old Style", serif; }
 .agent-identity .eyebrow { color: var(--amber); }
 .agent-panel.is-layout-full .agent-identity { flex-direction: column; align-items: flex-start; gap: 12px; }
@@ -259,9 +261,13 @@ body.is-resizing-agent .dashboard-with-agent { transition: none; }
 .agent-orbit i:nth-child(1) { top: 3px; left: 20px; }
 .agent-orbit i:nth-child(2) { right: 4px; bottom: 9px; }
 .agent-orbit i:nth-child(3) { left: 5px; bottom: 8px; }
-.agent-header-actions { display: grid; grid-template-columns: auto auto; align-items: center; justify-items: end; gap: 6px; }
-.agent-conversation-control { grid-column: 1 / -1; display: flex; align-items: center; gap: 5px; }
+.agent-header-actions { min-width: 0; display: grid; grid-template-columns: auto auto; align-items: center; justify-items: end; gap: 6px; }
+.agent-panel.is-layout-panel .agent-header-actions { width: 180px; flex: 0 1 180px; grid-template-columns: minmax(0, 1fr) auto; }
+.agent-conversation-control { min-width: 0; grid-column: 1 / -1; display: flex; align-items: center; gap: 5px; }
 .agent-conversation-control select { width: min(220px, 26vw); min-height: 28px; padding: 0 22px 0 7px; border: 1px solid var(--line); background: #f6f7f3; color: var(--ink); font: 9px/1 "SFMono-Regular", Consolas, monospace; }
+.agent-panel.is-layout-panel .agent-conversation-control select { min-width: 0; width: auto; flex: 1; }
+.agent-panel.is-layout-panel .agent-identity h2,
+.agent-panel.is-layout-panel .agent-identity .eyebrow { overflow-wrap: anywhere; }
 .agent-conversation-control button { min-height: 28px; padding: 0 8px; border: 1px solid var(--line); background: transparent; color: var(--ink); font: 8px/1 "SFMono-Regular", Consolas, monospace; text-transform: uppercase; }
 .agent-conversation-control select:disabled,.agent-conversation-control button:disabled { color: var(--dim); cursor: wait; }
 .agent-model-control { grid-column: 1 / -1; display: grid; grid-template-columns: auto minmax(0, 1fr); align-items: center; gap: 7px; color: var(--dim); text-transform: uppercase; font: 7px/1 "SFMono-Regular", Consolas, monospace; letter-spacing: .1em; }
@@ -283,7 +289,7 @@ body.is-resizing-agent .dashboard-with-agent { transition: none; }
 .agent-layout-controls button:hover { color: var(--signal); }
 .agent-layout-controls button[aria-pressed="true"] { color: #fff; background: var(--signal); }
 .agent-layout-controls svg { width: 17px; height: 17px; }
-.agent-messages { min-height: 0; padding: 24px 22px; overflow-y: auto; scrollbar-color: var(--line-bright) transparent; }
+.agent-messages { min-width: 0; min-height: 0; padding: 24px 22px; overflow-y: auto; scrollbar-color: var(--line-bright) transparent; }
 .agent-empty { min-height: 100%; display: flex; flex-direction: column; justify-content: center; }
 .agent-empty-mark { width: 46px; height: 46px; margin-bottom: 22px; display: grid; place-items: center; color: var(--amber); border: 1px solid rgba(154,91,21,.36); font: 9px/1 "SFMono-Regular", Consolas, monospace; letter-spacing: .12em; }
 .agent-empty h3 { margin-bottom: 8px; color: var(--ink); font: 400 22px/1.2 Baskerville, "Iowan Old Style", serif; }
@@ -326,7 +332,7 @@ body.is-resizing-agent .dashboard-with-agent { transition: none; }
 .agent-error span { color: var(--red); font: 7px/1 "SFMono-Regular", Consolas, monospace; letter-spacing: .12em; }
 .agent-error p { margin: 7px 0; color: #84423e; font-size: 10px; line-height: 1.4; }
 .agent-error button { padding: 0; border: 0; background: transparent; color: var(--red); font-size: 9px; text-decoration: underline; }
-.agent-composer { padding: 15px 22px 20px; border-top: 1px solid var(--line-bright); background: #faf9f5; }
+.agent-composer { min-width: 0; padding: 15px 22px 20px; border-top: 1px solid var(--line-bright); background: #faf9f5; }
 .agent-upload-control { margin-bottom: 10px; display: flex; align-items: center; gap: 9px; }
 .agent-upload-control input { position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(0 0 0 0); clip-path: inset(50%); white-space: nowrap; }
 .agent-upload-control button { padding: 0; color: var(--amber); border: 0; background: transparent; text-transform: uppercase; font: 8px/1 "SFMono-Regular", Consolas, monospace; letter-spacing: .09em; }

--- a/src/web/e2e/gig-board.e2e.ts
+++ b/src/web/e2e/gig-board.e2e.ts
@@ -112,6 +112,31 @@ test("mobile board remains usable", async ({ page }) => {
 });
 
 test("agent controls stay inside constrained standalone and tablet viewports", async ({ page }) => {
+  const longResponse = Array.from(
+    { length: 80 },
+    (_, index) => `Conversation detail ${index + 1}: keep the next action concise and evidence-based.`,
+  ).join("\n");
+  const stream = [
+    'data: {"type":"start","messageId":"assistant-constrained"}',
+    'data: {"type":"start-step"}',
+    'data: {"type":"text-start","id":"text-constrained"}',
+    `data: ${JSON.stringify({ type: "text-delta", id: "text-constrained", delta: longResponse })}`,
+    'data: {"type":"text-end","id":"text-constrained"}',
+    'data: {"type":"finish-step"}',
+    'data: {"type":"finish"}',
+    "data: [DONE]",
+    "",
+  ].join("\n\n");
+  await page.route("**/api/agent/messages", route => route.fulfill({
+    status: 200,
+    headers: {
+      "content-type": "text/event-stream",
+      "x-vercel-ai-ui-message-stream": "v1",
+      "cache-control": "no-store",
+    },
+    body: stream,
+  }));
+
   const assertControlsInsideViewport = async () => {
     const panel = page.getByRole("complementary", { name: "GigFinder" });
     const messages = panel.locator(".agent-messages");
@@ -140,6 +165,7 @@ test("agent controls stay inside constrained standalone and tablet viewports", a
     expect(sendBox.y + sendBox.height).toBeLessThanOrEqual(panelBottom);
     expect(messagesBox.y + messagesBox.height).toBeLessThanOrEqual(composerBox.y);
     expect(await messages.evaluate(element => getComputedStyle(element).overflowY)).toBe("auto");
+    expect(await messages.evaluate(element => element.scrollHeight > element.clientHeight)).toBe(true);
   };
 
   // The reporter's 2934 × 1856 screenshot was captured at device scale factor 2.
@@ -150,6 +176,8 @@ test("agent controls stay inside constrained standalone and tablet viewports", a
     await panel.getByRole("button", { name: "Dock agent to side" }).click();
   }
   await panel.getByLabel("Message GigFinderAgent").fill("Keep the submit control visible.");
+  await panel.getByRole("button", { name: "Send" }).click();
+  await expect(panel).toContainText("Conversation detail 80");
   await assertControlsInsideViewport();
 
   await page.setViewportSize({ width: 820, height: 600 });

--- a/src/web/e2e/gig-board.e2e.ts
+++ b/src/web/e2e/gig-board.e2e.ts
@@ -111,6 +111,51 @@ test("mobile board remains usable", async ({ page }) => {
   await page.screenshot({ path: "test-results/playwright/agent-mobile.png", fullPage: false });
 });
 
+test("agent controls stay inside constrained standalone and tablet viewports", async ({ page }) => {
+  const assertControlsInsideViewport = async () => {
+    const panel = page.getByRole("complementary", { name: "GigFinder" });
+    const messages = panel.locator(".agent-messages");
+    const composer = panel.locator(".agent-composer");
+    const close = panel.getByRole("button", { name: "Close GigFinder" });
+    const send = panel.getByRole("button", { name: "Send" });
+
+    await expect(panel).toBeVisible();
+    await expect(close).toBeInViewport();
+    await expect(send).toBeInViewport();
+
+    const [panelBox, messagesBox, composerBox, closeBox, sendBox] = await Promise.all([
+      panel.boundingBox(),
+      messages.boundingBox(),
+      composer.boundingBox(),
+      close.boundingBox(),
+      send.boundingBox(),
+    ]);
+    if (!panelBox || !messagesBox || !composerBox || !closeBox || !sendBox) {
+      throw new Error("Expected the constrained agent controls to have layout boxes.");
+    }
+    const panelRight = panelBox.x + panelBox.width;
+    const panelBottom = panelBox.y + panelBox.height;
+    expect(closeBox.x + closeBox.width).toBeLessThanOrEqual(panelRight);
+    expect(sendBox.x + sendBox.width).toBeLessThanOrEqual(panelRight);
+    expect(sendBox.y + sendBox.height).toBeLessThanOrEqual(panelBottom);
+    expect(messagesBox.y + messagesBox.height).toBeLessThanOrEqual(composerBox.y);
+    expect(await messages.evaluate(element => getComputedStyle(element).overflowY)).toBe("auto");
+  };
+
+  // The reporter's 2934 × 1856 screenshot was captured at device scale factor 2.
+  await page.setViewportSize({ width: 1467, height: 928 });
+  await page.goto("/");
+  const panel = page.getByRole("complementary", { name: "GigFinder" });
+  if (await panel.getAttribute("data-layout") === "full") {
+    await panel.getByRole("button", { name: "Dock agent to side" }).click();
+  }
+  await panel.getByLabel("Message GigFinderAgent").fill("Keep the submit control visible.");
+  await assertControlsInsideViewport();
+
+  await page.setViewportSize({ width: 820, height: 600 });
+  await assertControlsInsideViewport();
+});
+
 test("GigFinderAgent streams guidance and remains available across dashboard views", async ({ page }) => {
   const diagnostics: string[] = [];
   page.on("console", message => {


### PR DESCRIPTION
## Summary

- constrain the agent panel grid to the available dynamic viewport height and width
- keep header actions, composer, and submit control inside the side panel while the conversation region scrolls independently
- cover an overflowing conversation at the reporter-equivalent 1467×928 viewport and a constrained 820×600 tablet viewport

Closes #110

## Validation

- `bun run check` — passed (234 tests)
- `bun run build` — passed
- `bun run test:e2e` — passed (11 tests)

## Smoke evidence

Developer:

- Exact HEAD: `b273bc36215ea02ff91461a56df58650fc3ae628`
- `bun run smoke:deterministic`: passed; 6.363s; 27 tools, 57 registry validations, restart and hydration passed
- `bun run smoke:live`: passed; normal response; 8.631s within 90s timeout; no read-only tool calls

Independent reviewer:

- Exact reviewed HEAD: `b273bc36215ea02ff91461a56df58650fc3ae628`
- `bun run smoke:deterministic`: passed; 6.569s; 27 tools, 57 registry validations, restart and hydration passed
- `bun run smoke:live`: passed; normal response; 9.511s within 90s timeout; no read-only tool calls

Any commit after a recorded run invalidates that run. Fixes require both smoke
commands and independent review to run again against the new exact HEAD.
