### PR TITLE
Restore Scout default title and location filters

### DIFF
--- a/docs/architecture/configuration.md
+++ b/docs/architecture/configuration.md
@@ -53,3 +53,20 @@ own page size and exhaustion semantics. Runtime policy owns hard request, page,
 record, response-size, retry, and duration ceilings. A scan continues until the
 source proves exhaustion; reaching a ceiling first produces an explicit
 `source_limit_reached` incomplete outcome.
+
+As a temporary application-level exception, a full Scout run resolves an
+omitted or empty title-term dimension to Director, Senior Director, Sr.
+Director, Senior Vice President, SVP, Vice President, VP Engineering, Head of
+Engineering, and Head of Technology. It resolves an omitted or empty location
+dimension to Seattle, Bellevue, Redmond, Remote, and Washington. A non-empty
+explicit dimension replaces its defaults. Scout persists the resolved profile
+as the run's immutable snapshot and dispatches it uniformly; these values do
+not enter company configurations or reusable templates.
+
+After JSON or DOM normalization, the common sourcing validation path applies
+the captured profile case-insensitively. Terms are ORed within the title
+dimension, locations are ORed within the location dimension, and both
+dimensions must match. Nonmatching candidates remain evaluated rejections with
+profile-title or profile-location diagnostics so reconciliation stays
+balanced. Template-side search parameters remain acquisition optimizations,
+not the enforcement boundary.

--- a/docs/product/006-gig-scout.md
+++ b/docs/product/006-gig-scout.md
@@ -13,10 +13,11 @@
 ## 🛠️ Functional Specifications
 
 - **Trigger**: The user launches a full scan from the Gig Scout workspace and later opens its progress or results.
-- **Input Data**: Private target-company configuration, one authoritative official listing source per company, reusable generic source adapters, and candidate-specific search and exclusion criteria.
+- **Input Data**: Private target-company configuration, one authoritative official listing source per company, reusable generic source adapters, and candidate-specific search and exclusion criteria. For the current release, Scout supplies temporary application defaults when a run omits or empties title terms or locations; a non-empty run dimension replaces its default.
 - **Happy Path**:
   1. The system accepts one durable run and processes each configured company independently with bounded retries and concurrency.
-  2. The user can follow durable progress and inspect accepted positions plus clear company and source outcomes after completion.
+  2. The resolved title and location profile is captured immutably with the run and applied to every company source.
+  3. The user can follow durable progress and inspect accepted positions plus clear company and source outcomes after completion.
 - **Alternative Paths**:
   - A source is verified empty -> Record success only when the source's explicit semantics and reconciliation support that conclusion.
   - A page fails, repeats prior results, or cannot be parsed reliably -> Preserve diagnostics and report a non-success outcome rather than silently omitting jobs.
@@ -28,8 +29,9 @@
   - **Given** a configured full scan, **When** the initiating request ends, **Then** accepted work continues durably and remains observable.
   - **Given** a completed source attempt, **When** its outcome is marked successful, **Then** source-reported, received, parsed, evaluated, accepted, rejected, page-validation, and distinct-identity evidence reconciles.
   - **Given** repeated delivery or recovery, **When** a company job runs again, **Then** logical outcomes and stored descriptions are not duplicated.
+  - **Given** normalized candidates from any JSON or DOM source, **When** title and location filters are active, **Then** Scout accepts a position only when its title matches at least one title term and its location matches at least one location term, case-insensitively; profile rejections remain reconciled diagnostics.
 - **Error Boundaries**: One company's exhaustion or unsupported source becomes an explicit company outcome and does not erase other companies' completed results.
-- **Data Validation**: Only official configured sources are scanned; private targeting stays outside tracked adapters; accepted postings have real posting identity and application semantics.
+- **Data Validation**: Only official configured sources are scanned; private targeting stays outside tracked adapters; accepted postings have real posting identity and application semantics. Temporary default title terms are Director, Senior Director, Sr. Director, Senior Vice President, SVP, Vice President, VP Engineering, Head of Engineering, and Head of Technology. Default locations are Seattle, Bellevue, Redmond, Remote, and Washington.
 
 ## 🛑 Out of Scope
 

--- a/src/core/scout/engine/index.ts
+++ b/src/core/scout/engine/index.ts
@@ -7,6 +7,8 @@ export {
 export {
   companyScanRequestSchema,
   scoutSearchProfileSchema,
+  defaultScoutSearchProfile,
+  resolveScoutSearchProfile,
   sourceConfigurationSchema,
 } from "../sourcing/contracts";
 export type * from "../sourcing/contracts";

--- a/src/core/scout/engine/runs.ts
+++ b/src/core/scout/engine/runs.ts
@@ -3,7 +3,7 @@ import type {
   ScoutSearchProfile,
   SourceConfiguration,
 } from "../sourcing/contracts";
-import { scoutSearchProfileSchema } from "../sourcing/contracts";
+import { resolveScoutSearchProfile } from "../sourcing/contracts";
 
 export type ScoutRunStatus =
   | "queued"
@@ -30,6 +30,7 @@ export interface ScoutRunSummary {
   companyCount: number;
   succeededCount: number;
   failedCount: number;
+  searchProfile: ScoutSearchProfile;
 }
 export interface ScoutRunSourceDetail {
   id: string;
@@ -124,7 +125,7 @@ export class ScoutRunService {
     settings: Partial<{
       batchSize: number;
       concurrency: number;
-      searchProfile: ScoutSearchProfile;
+      searchProfile: Partial<ScoutSearchProfile>;
     }> = {},
   ) {
     const batchSize = settings.batchSize ?? this.defaults.batchSize;
@@ -133,9 +134,7 @@ export class ScoutRunService {
       throw new Error("Scout batch size must be from 1 through 100.");
     if (!Number.isInteger(concurrency) || concurrency < 1 || concurrency > 50)
       throw new Error("Scout concurrency must be from 1 through 50.");
-    const searchProfile = scoutSearchProfileSchema.parse(
-      settings.searchProfile ?? {},
-    );
+    const searchProfile = resolveScoutSearchProfile(settings.searchProfile);
     return this.store.startOrReuse(
       batchSize,
       concurrency,

--- a/src/core/scout/engine/test/runs.test.ts
+++ b/src/core/scout/engine/test/runs.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test";
+import {
+  defaultScoutSearchProfile,
+  resolveScoutSearchProfile,
+} from "../../sourcing/contracts";
+import { ScoutRunService, type ScoutRunStore } from "../runs";
+
+const store = (captured: Array<unknown>): ScoutRunStore =>
+  ({
+    startOrReuse(batchSize, concurrency, createdAt, searchProfile) {
+      captured.push(searchProfile);
+      return {
+        created: true,
+        run: {
+          id: "synthetic-run",
+          status: "completed",
+          batchSize,
+          concurrency,
+          createdAt,
+          startedAt: createdAt,
+          completedAt: createdAt,
+          companyCount: 0,
+          succeededCount: 0,
+          failedCount: 0,
+          searchProfile: searchProfile!,
+        },
+      };
+    },
+    list: () => [],
+    get: () => null,
+    pendingJobs: () => [],
+    nonterminalJobs: () => [],
+    markDispatched: () => {},
+    commitResult: () => {},
+    commitInfrastructureFailure: () => {},
+    positions: () => ({ items: [], offset: 0, limit: 20, total: 0 }),
+  }) satisfies ScoutRunStore;
+
+describe("Scout run search profiles", () => {
+  test("uses independent copies of the temporary defaults for omitted and empty dimensions", () => {
+    expect(resolveScoutSearchProfile()).toEqual({
+      terms: [...defaultScoutSearchProfile.terms],
+      locations: [...defaultScoutSearchProfile.locations],
+    });
+    expect(resolveScoutSearchProfile({ terms: [], locations: [] })).toEqual(
+      {
+        terms: [...defaultScoutSearchProfile.terms],
+        locations: [...defaultScoutSearchProfile.locations],
+      },
+    );
+    expect(resolveScoutSearchProfile().terms).not.toBe(
+      defaultScoutSearchProfile.terms,
+    );
+  });
+
+  test("non-empty explicit dimensions replace only that dimension", () => {
+    expect(resolveScoutSearchProfile({ terms: ["Architect"] })).toEqual({
+      terms: ["Architect"],
+      locations: [...defaultScoutSearchProfile.locations],
+    });
+    expect(resolveScoutSearchProfile({ locations: ["Synthetic Region"] })).toEqual(
+      {
+        terms: [...defaultScoutSearchProfile.terms],
+        locations: ["Synthetic Region"],
+      },
+    );
+  });
+
+  test("startFull persists the resolved profile at the service boundary", () => {
+    const captured: unknown[] = [];
+    new ScoutRunService(store(captured)).startFull({
+      searchProfile: { terms: ["Architect"], locations: [] },
+    });
+    expect(captured).toEqual([
+      {
+        terms: ["Architect"],
+        locations: [...defaultScoutSearchProfile.locations],
+      },
+    ]);
+  });
+});

--- a/src/core/scout/engine/test/scan-company.test.ts
+++ b/src/core/scout/engine/test/scan-company.test.ts
@@ -6,6 +6,84 @@ import {
 } from "..";
 
 describe("scanCompany", () => {
+  test("applies one title-and-location profile after JSON and DOM normalization", async () => {
+    const profile = { terms: ["DIRECTOR", "Head of Technology"], locations: ["remote", "Seattle"] };
+    const result = await scanCompany(
+      {
+        companyId: "synthetic-company",
+        configurationVersionId: "synthetic-config",
+        searchProfile: profile,
+        sources: [
+          {
+            key: "structured",
+            type: "json",
+            url: "https://careers.example.test/api/jobs",
+            active: true,
+            method: "GET",
+            recordsPath: "jobs",
+            fields: { id: "id", title: "title", url: "url", location: "location" },
+          },
+          {
+            key: "markup",
+            type: "html",
+            url: "https://careers.example.test/jobs",
+            active: true,
+            listingSelector: ".posting",
+            titleField: { selector: ".title" },
+            urlField: { selector: "a", attribute: "href" },
+            locationField: { selector: ".location" },
+            listingSurfaceSelector: "main",
+          },
+        ],
+      },
+      {
+        http: {
+          async request(input) {
+            if (input.url.includes("/api/"))
+              return {
+                status: 200,
+                url: input.url,
+                headers: {},
+                body: JSON.stringify({ jobs: [
+                  { id: "json-match", title: "Senior Director, Platforms", location: "Fully Remote", url: "/jobs/json-match" },
+                  { id: "json-title-miss", title: "Staff Engineer", location: "Seattle, WA", url: "/jobs/json-title-miss" },
+                  { id: "json-location-miss", title: "Director of Engineering", location: "Synthetic Region", url: "/jobs/json-location-miss" },
+                  { id: "json-null-location", title: "Director of Technology", location: null, url: "/jobs/json-null-location" },
+                ] }),
+              };
+            return {
+              status: 200,
+              url: input.url,
+              headers: {},
+              body: `<main>
+                <article class="posting"><span class="title">Head of   Technology</span><span class="location">SEATTLE, Washington</span><a href="/jobs/dom-match">Open</a></article>
+                <article class="posting"><span class="title">Product Manager</span><span class="location">Remote</span><a href="/jobs/dom-title-miss">Open</a></article>
+                <article class="posting"><span class="title">Vice President</span><span class="location">Synthetic Region</span><a href="/jobs/dom-location-miss">Open</a></article>
+              </main>`,
+            };
+          },
+        },
+      },
+    );
+
+    expect(result.positions.map((position) => position.externalId)).toEqual([
+      "json-match",
+      null,
+    ]);
+    for (const source of result.sources) {
+      const attempt = source.attempts[0]!;
+      expect(attempt.recordsEvaluated).toBe(attempt.recordsReceived);
+      expect(attempt.acceptedCount + attempt.rejectedCount).toBe(
+        attempt.recordsReceived ?? 0,
+      );
+      expect(attempt.diagnostics).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ code: "profile_title_mismatch" }),
+          expect.objectContaining({ code: "profile_location_mismatch" }),
+        ]),
+      );
+    }
+  });
   test("generic JSON can acquire a root-array listing surface", async () => {
     const result = await scanCompany(
       {

--- a/src/core/scout/sourcing/adapters/index.ts
+++ b/src/core/scout/sourcing/adapters/index.ts
@@ -58,7 +58,11 @@ export async function scanSource(
             "Runtime safety policy was reached before source exhaustion was proven.",
         });
         if (final) final.validationStatus = "failed";
-        const validation = validatePositions(positions, surfaceVerified);
+        const validation = validatePositions(
+          positions,
+          surfaceVerified,
+          searchProfile,
+        );
         applyValidation(
           attemptPositions,
           validation.accepted,
@@ -251,7 +255,11 @@ export async function scanSource(
       }
       if (!pageComplete) {
         if (positions.length) {
-          const validation = validatePositions(positions, surfaceVerified);
+          const validation = validatePositions(
+            positions,
+            surfaceVerified,
+            searchProfile,
+          );
           applyValidation(
             attemptPositions,
             validation.accepted,
@@ -320,7 +328,11 @@ export async function scanSource(
       if (lastAttempt.recordsReceived === 0) break;
     }
   }
-  const validation = validatePositions(positions, surfaceVerified);
+  const validation = validatePositions(
+    positions,
+    surfaceVerified,
+    searchProfile,
+  );
   applyValidation(
     attemptPositions,
     validation.accepted,

--- a/src/core/scout/sourcing/contracts.ts
+++ b/src/core/scout/sourcing/contracts.ts
@@ -159,6 +159,41 @@ export const scoutSearchProfileSchema = z
   .strict()
   .default({ terms: [], locations: [] });
 
+export const defaultScoutSearchProfile = Object.freeze({
+  terms: Object.freeze([
+    "Director",
+    "Senior Director",
+    "Sr. Director",
+    "Senior Vice President",
+    "SVP",
+    "Vice President",
+    "VP Engineering",
+    "Head of Engineering",
+    "Head of Technology",
+  ]),
+  locations: Object.freeze([
+    "Seattle",
+    "Bellevue",
+    "Redmond",
+    "Remote",
+    "Washington",
+  ]),
+});
+
+export function resolveScoutSearchProfile(
+  profile?: Partial<ScoutSearchProfile>,
+): ScoutSearchProfile {
+  const parsed = scoutSearchProfileSchema.parse(profile ?? {});
+  return {
+    terms: parsed.terms.length
+      ? [...parsed.terms]
+      : [...defaultScoutSearchProfile.terms],
+    locations: parsed.locations.length
+      ? [...parsed.locations]
+      : [...defaultScoutSearchProfile.locations],
+  };
+}
+
 export const companyScanRequestSchema = z
   .object({
     companyId: z.string().trim().min(1).max(100),

--- a/src/core/scout/sourcing/diagnostics.ts
+++ b/src/core/scout/sourcing/diagnostics.ts
@@ -2,16 +2,44 @@ import type {
   NormalizedPosition,
   SourceDiagnostic,
   SourceOutcomeStatus,
+  ScoutSearchProfile,
 } from "./contracts";
+
+const normalizeMatchText = (value: string) =>
+  value.normalize("NFKC").replace(/\s+/g, " ").trim().toLocaleLowerCase();
+
+export function positionMatchesSearchProfile(
+  position: Pick<NormalizedPosition, "title" | "location">,
+  profile: ScoutSearchProfile,
+) {
+  const title = normalizeMatchText(position.title);
+  const location = position.location
+    ? normalizeMatchText(position.location)
+    : null;
+  return {
+    title: profile.terms.length
+      ? profile.terms.some((term) => title.includes(normalizeMatchText(term)))
+      : true,
+    location: profile.locations.length
+      ? location !== null &&
+        profile.locations.some((item) =>
+          location.includes(normalizeMatchText(item)),
+        )
+      : true,
+  };
+}
 export function validatePositions(
   positions: NormalizedPosition[],
   surfaceVerified: boolean,
+  searchProfile: ScoutSearchProfile = { terms: [], locations: [] },
 ) {
   const accepted: NormalizedPosition[] = [];
   const seen = new Set<string>();
   let duplicateIdentities = 0;
   let invalidTitles = 0;
   let invalidUrls = 0;
+  let titleMismatches = 0;
+  let locationMismatches = 0;
   const rejectedPositions: Array<{
     position: NormalizedPosition;
     code: string;
@@ -46,6 +74,24 @@ export function validatePositions(
       });
       continue;
     }
+    const profileMatch = positionMatchesSearchProfile(position, searchProfile);
+    if (!profileMatch.title) {
+      titleMismatches++;
+      rejectedPositions.push({
+        position,
+        code: "profile_title_mismatch",
+        message: "Candidate title did not match the run search profile.",
+      });
+    }
+    if (!profileMatch.location) {
+      locationMismatches++;
+      rejectedPositions.push({
+        position,
+        code: "profile_location_mismatch",
+        message: "Candidate location did not match the run search profile.",
+      });
+    }
+    if (!profileMatch.title || !profileMatch.location) continue;
     seen.add(identity);
     accepted.push(position);
   }
@@ -71,7 +117,22 @@ export function validatePositions(
       count: invalidUrls,
       message: "Candidates did not provide an HTTPS official detail URL.",
     });
-  const rejected = duplicateIdentities + invalidTitles + invalidUrls;
+  if (titleMismatches)
+    diagnostics.push({
+      code: "profile_title_mismatch",
+      category: "validation",
+      count: titleMismatches,
+      message: "Candidate titles did not match the run search profile.",
+    });
+  if (locationMismatches)
+    diagnostics.push({
+      code: "profile_location_mismatch",
+      category: "validation",
+      count: locationMismatches,
+      message: "Candidate locations did not match the run search profile.",
+    });
+  const rejected = new Set(rejectedPositions.map(({ position }) => position))
+    .size;
   let status: SourceOutcomeStatus = accepted.length
     ? invalidTitles + invalidUrls
       ? "partial"

--- a/src/data/scout-run-store.ts
+++ b/src/data/scout-run-store.ts
@@ -28,6 +28,7 @@ const summary = (row: Record<string, unknown>): ScoutRunSummary => ({
   companyCount: Number(row.company_count),
   succeededCount: Number(row.succeeded_count),
   failedCount: Number(row.failed_count),
+  searchProfile: JSON.parse(String(row.search_profile_json)),
 });
 export class SqliteScoutRunStore implements ScoutRunStore {
   constructor(

--- a/src/data/test/scout-run-store.test.ts
+++ b/src/data/test/scout-run-store.test.ts
@@ -49,6 +49,8 @@ test("a run-owned search profile is dispatched uniformly without changing compan
     terms: ["synthetic specialty"],
     locations: ["Synthetic Region"],
   });
+  expect(store.list()[0]?.searchProfile).toEqual(job.searchProfile);
+  expect(store.get(job.runId)?.searchProfile).toEqual(job.searchProfile);
   expect(job.sources[0]).not.toHaveProperty("searchTerms");
   expect(job.sources[0]).not.toHaveProperty("maxPages");
 });

--- a/src/operations/scout-runtime.ts
+++ b/src/operations/scout-runtime.ts
@@ -135,6 +135,18 @@ export class ScoutRuntime {
                   (sum, attempt) => sum + attempt.rejectedCount,
                   0,
                 ),
+                profileRejections: source.attempts.reduce(
+                  (counts, attempt) => {
+                    for (const diagnostic of attempt.diagnostics) {
+                      if (diagnostic.code === "profile_title_mismatch")
+                        counts.title += diagnostic.count;
+                      if (diagnostic.code === "profile_location_mismatch")
+                        counts.location += diagnostic.count;
+                    }
+                    return counts;
+                  },
+                  { title: 0, location: 0 },
+                ),
                 diagnosticCodes: [
                   ...new Set(
                     source.attempts.flatMap((attempt) =>

--- a/src/web/client/GigScoutPage.tsx
+++ b/src/web/client/GigScoutPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { defaultScoutSearchProfile } from "../../core/scout/engine";
 type Run = {
   id: string;
   status: string;
@@ -7,6 +8,7 @@ type Run = {
   companyCount: number;
   succeededCount: number;
   failedCount: number;
+  searchProfile: { terms: string[]; locations: string[] };
 };
 type Position = {
   id: string;
@@ -67,8 +69,12 @@ export function GigScoutPage() {
   const [textFilter, setTextFilter] = useState("");
   const [offset, setOffset] = useState(0);
   const [total, setTotal] = useState(0);
-  const [searchTerms, setSearchTerms] = useState("");
-  const [searchLocations, setSearchLocations] = useState("");
+  const [searchTerms, setSearchTerms] = useState(
+    defaultScoutSearchProfile.terms.join(", "),
+  );
+  const [searchLocations, setSearchLocations] = useState(
+    defaultScoutSearchProfile.locations.join(", "),
+  );
   const limit = 20;
   const [error, setError] = useState<string | null>(null);
   const refresh = async () => {
@@ -203,6 +209,14 @@ export function GigScoutPage() {
                 <span>{run.companyCount} companies</span>
               </div>
             ))}
+          {detail && (
+            <div className="scout-summary" aria-label="Run search profile">
+              <span>Titles: {detail.searchProfile.terms.join(", ")}</span>
+              <span>
+                Locations: {detail.searchProfile.locations.join(", ")}
+              </span>
+            </div>
+          )}
           <div className="scout-filters">
             <label>
               Company{" "}

--- a/src/web/e2e/gig-scout.e2e.ts
+++ b/src/web/e2e/gig-scout.e2e.ts
@@ -18,8 +18,18 @@ test("starts, leaves, and reopens a persisted empty Gig Scout run", async ({
   await expect(
     page.getByRole("heading", { name: "Gig Scout", exact: true }),
   ).toBeVisible();
-  await page.getByLabel("Search terms").fill("synthetic systems, orchard");
-  await page.getByLabel("Search locations").fill("Synthetic Region");
+  await expect(page.getByLabel("Search terms", { exact: true })).toHaveValue(
+    /Director/,
+  );
+  await expect(
+    page.getByLabel("Search locations", { exact: true }),
+  ).toHaveValue(/Seattle/);
+  await page
+    .getByLabel("Search terms", { exact: true })
+    .fill("synthetic systems, orchard");
+  await page
+    .getByLabel("Search locations", { exact: true })
+    .fill("Synthetic Region");
   await page.getByRole("button", { name: "Start full scan" }).click();
   expect(submittedProfile).toEqual({
     searchProfile: {
@@ -28,6 +38,12 @@ test("starts, leaves, and reopens a persisted empty Gig Scout run", async ({
     },
   });
   await expect(page.getByRole("status")).toContainText("completed");
+  await expect(page.getByLabel("Run search profile")).toContainText(
+    "synthetic systems",
+  );
+  await expect(page.getByLabel("Run search profile")).toContainText(
+    "Synthetic Region",
+  );
   await page.getByRole("button", { name: /Opportunities/ }).click();
   await page.getByRole("button", { name: /Gig Scout/ }).click();
   await expect(


### PR DESCRIPTION
## Summary

- restore the temporary Scout title and location defaults at the core run boundary
- enforce every captured profile after JSON or DOM normalization with reconciled rejection diagnostics
- show editable defaults and the selected run's immutable profile in the dashboard

Closes #117

## Validation

- `bun run check`
- `bun run build`
- `bun run test:e2e` (12 passed)
- focused JSON/DOM, run-service, persistence, and Scout browser regression coverage

## Smoke evidence

Developer:

- Exact HEAD: `7b218e13865b7e9d34c11b0ea1f804ba63540b8c`
- `bun run smoke:deterministic`: passed; 8,865 ms; 27 tools, 57 registry validations, restart and hydration passed
- `bun run smoke:live`: passed; 7,032 ms; normal response within the 90,000 ms bound, no tools invoked

Independent reviewer:

- Exact reviewed HEAD: `7b218e13865b7e9d34c11b0ea1f804ba63540b8c`
- `bun run smoke:deterministic`: passed; 8,764 ms; 27 tools, 57 registry validations, restart and hydration passed
- `bun run smoke:live`: passed; 6,825 ms; normal response within the 90,000 ms bound, no tools invoked

Any commit after a recorded run invalidates that run. Fixes require both smoke
commands and independent review to run again against the new exact HEAD.