### PR TITLE
Prevent deployment from deleting runtime artifacts

### DIFF
--- a/bin/deploy-local.sh
+++ b/bin/deploy-local.sh
@@ -62,10 +62,6 @@ codex_home=$(CDPATH= cd -- "${codex_home}" && pwd -P)
   || fail "production database does not exist; run bin/bootstrap-production.sh first"
 [ -x "${sync_bin}" ] || fail "production input synchronizer is unavailable: ${sync_bin}"
 
-echo "Synchronizing production profile, configuration, and artifacts..."
-"${sync_bin}" "${source_root}" "${state_root}" "${config_file}"
-[ -f "${config_file}" ] || fail "production configuration was not created"
-
 "${docker_bin}" info >/dev/null 2>&1 || fail "Docker is unavailable; start OrbStack"
 
 image="${image_name}:${tag}"
@@ -98,18 +94,44 @@ maintenance() {
     "${image}" bun dist/server/maintenance.js "$@"
 }
 
+if [ "${old_running}" = true ]; then
+  "${docker_bin}" stop "${container_name}" >/dev/null
+fi
+
 echo "Creating verified production backup..."
-backup_output=$(maintenance backup)
+if ! maintenance validate; then
+  if [ "${old_running}" = true ]; then "${docker_bin}" start "${container_name}" >/dev/null; fi
+  fail "pre-deployment database or runtime-artifact validation failed"
+fi
+if ! artifact_baseline=$(maintenance artifacts); then
+  if [ "${old_running}" = true ]; then "${docker_bin}" start "${container_name}" >/dev/null; fi
+  fail "pre-deployment runtime-artifact inventory failed"
+fi
+echo "${artifact_baseline}"
+if ! backup_output=$(maintenance backup); then
+  if [ "${old_running}" = true ]; then "${docker_bin}" start "${container_name}" >/dev/null; fi
+  fail "consistent database and runtime-artifact backup failed"
+fi
 echo "${backup_output}"
 backup_path=$(printf '%s\n' "${backup_output}" \
   | sed -n 's/.*"path":"\([^"]*\)".*/\1/p' | head -n 1)
 [ -n "${backup_path}" ] || fail "maintenance backup did not report a backup path"
 
-if [ "${old_running}" = true ]; then
-  "${docker_bin}" stop "${container_name}" >/dev/null
+echo "Synchronizing source-managed production inputs..."
+if ! "${sync_bin}" "${source_root}" "${state_root}" "${config_file}"; then
+  if [ "${old_running}" = true ]; then "${docker_bin}" start "${container_name}" >/dev/null; fi
+  fail "source-managed input synchronization failed"
+fi
+if [ ! -f "${config_file}" ]; then
+  if [ "${old_running}" = true ]; then "${docker_bin}" start "${container_name}" >/dev/null; fi
+  fail "production configuration was not created"
+fi
+if ! maintenance validate || ! maintenance artifacts "${artifact_baseline}"; then
+  if [ "${old_running}" = true ]; then "${docker_bin}" start "${container_name}" >/dev/null; fi
+  fail "source synchronization introduced an integrity regression"
 fi
 
-if ! maintenance migrate || ! maintenance validate; then
+if ! maintenance migrate || ! maintenance validate || ! maintenance artifacts "${artifact_baseline}"; then
   echo "Migration or validation failed; restoring ${backup_path}..." >&2
   if maintenance restore "${backup_path}"; then
     if [ "${old_running}" = true ]; then
@@ -177,6 +199,11 @@ if [ "${healthy}" != true ]; then
   "${docker_bin}" logs "${container_name}" >&2 || true
   rollback || true
   fail "new container did not become healthy"
+fi
+
+if ! maintenance validate || ! maintenance artifacts "${artifact_baseline}"; then
+  rollback || true
+  fail "post-cutover database or runtime-artifact validation failed"
 fi
 
 if [ "${old_exists}" = true ]; then

--- a/bin/deploy-local.sh
+++ b/bin/deploy-local.sh
@@ -118,20 +118,19 @@ backup_path=$(printf '%s\n' "${backup_output}" \
 [ -n "${backup_path}" ] || fail "maintenance backup did not report a backup path"
 
 echo "Synchronizing source-managed production inputs..."
-if ! sync_output=$("${sync_bin}" "${source_root}" "${state_root}" "${config_file}"); then
+input_manifest="${state_root}/data/deployment-inputs-${revision}-$$.json"
+if ! sync_output=$("${sync_bin}" "${source_root}" "${state_root}" "${config_file}" "${input_manifest}"); then
   if [ "${old_running}" = true ]; then "${docker_bin}" start "${container_name}" >/dev/null; fi
   fail "source-managed input synchronization failed"
 fi
 echo "${sync_output}"
-input_manifest=$(printf '%s\n' "${sync_output}" \
-  | sed -n 's/.*"transactionManifest":[[:space:]]*"\([^"]*\)".*/\1/p' | head -n 1)
-[ -n "${input_manifest}" ] || fail "source synchronization did not report a rollback manifest"
 if [ ! -f "${config_file}" ]; then
+  "${sync_bin}" --rollback "${input_manifest}" "${source_root}" "${state_root}" "${config_file}" || true
   if [ "${old_running}" = true ]; then "${docker_bin}" start "${container_name}" >/dev/null; fi
   fail "production configuration was not created"
 fi
 if ! maintenance validate || ! maintenance artifacts "${artifact_baseline}"; then
-  "${sync_bin}" --rollback "${input_manifest}" || true
+  "${sync_bin}" --rollback "${input_manifest}" "${source_root}" "${state_root}" "${config_file}" || true
   if [ "${old_running}" = true ]; then "${docker_bin}" start "${container_name}" >/dev/null; fi
   fail "source synchronization introduced an integrity regression"
 fi
@@ -139,7 +138,7 @@ fi
 if ! maintenance migrate || ! maintenance validate || ! maintenance artifacts "${artifact_baseline}"; then
   echo "Migration or validation failed; restoring ${backup_path}..." >&2
   if maintenance restore "${backup_path}"; then
-    "${sync_bin}" --rollback "${input_manifest}" || fail "production state restored but source-input rollback failed: ${input_manifest}"
+    "${sync_bin}" --rollback "${input_manifest}" "${source_root}" "${state_root}" "${config_file}" || fail "production state restored but source-input rollback failed: ${input_manifest}"
     if [ "${old_running}" = true ]; then
       "${docker_bin}" start "${container_name}" >/dev/null
     fi
@@ -161,7 +160,7 @@ rollback() {
     echo "Use the retained backup before restarting it: ${backup_path}" >&2
     return 1
   fi
-  if ! "${sync_bin}" --rollback "${input_manifest}"; then
+  if ! "${sync_bin}" --rollback "${input_manifest}" "${source_root}" "${state_root}" "${config_file}"; then
     echo "Source-input rollback failed; recovery manifest retained: ${input_manifest}" >&2
     return 1
   fi
@@ -216,7 +215,7 @@ if ! maintenance validate || ! maintenance artifacts "${artifact_baseline}"; the
   fail "post-cutover database or runtime-artifact validation failed"
 fi
 
-"${sync_bin}" --finalize "${input_manifest}"
+"${sync_bin}" --finalize "${input_manifest}" "${source_root}" "${state_root}" "${config_file}"
 
 if [ "${old_exists}" = true ]; then
   "${docker_bin}" rm "${previous_name}" >/dev/null

--- a/bin/deploy-local.sh
+++ b/bin/deploy-local.sh
@@ -118,15 +118,20 @@ backup_path=$(printf '%s\n' "${backup_output}" \
 [ -n "${backup_path}" ] || fail "maintenance backup did not report a backup path"
 
 echo "Synchronizing source-managed production inputs..."
-if ! "${sync_bin}" "${source_root}" "${state_root}" "${config_file}"; then
+if ! sync_output=$("${sync_bin}" "${source_root}" "${state_root}" "${config_file}"); then
   if [ "${old_running}" = true ]; then "${docker_bin}" start "${container_name}" >/dev/null; fi
   fail "source-managed input synchronization failed"
 fi
+echo "${sync_output}"
+input_manifest=$(printf '%s\n' "${sync_output}" \
+  | sed -n 's/.*"transactionManifest":[[:space:]]*"\([^"]*\)".*/\1/p' | head -n 1)
+[ -n "${input_manifest}" ] || fail "source synchronization did not report a rollback manifest"
 if [ ! -f "${config_file}" ]; then
   if [ "${old_running}" = true ]; then "${docker_bin}" start "${container_name}" >/dev/null; fi
   fail "production configuration was not created"
 fi
 if ! maintenance validate || ! maintenance artifacts "${artifact_baseline}"; then
+  "${sync_bin}" --rollback "${input_manifest}" || true
   if [ "${old_running}" = true ]; then "${docker_bin}" start "${container_name}" >/dev/null; fi
   fail "source synchronization introduced an integrity regression"
 fi
@@ -134,6 +139,7 @@ fi
 if ! maintenance migrate || ! maintenance validate || ! maintenance artifacts "${artifact_baseline}"; then
   echo "Migration or validation failed; restoring ${backup_path}..." >&2
   if maintenance restore "${backup_path}"; then
+    "${sync_bin}" --rollback "${input_manifest}" || fail "production state restored but source-input rollback failed: ${input_manifest}"
     if [ "${old_running}" = true ]; then
       "${docker_bin}" start "${container_name}" >/dev/null
     fi
@@ -153,6 +159,10 @@ rollback() {
   if ! maintenance restore "${backup_path}"; then
     echo "Automatic database restore failed. The prior container remains ${previous_name}." >&2
     echo "Use the retained backup before restarting it: ${backup_path}" >&2
+    return 1
+  fi
+  if ! "${sync_bin}" --rollback "${input_manifest}"; then
+    echo "Source-input rollback failed; recovery manifest retained: ${input_manifest}" >&2
     return 1
   fi
   if [ "${old_exists}" = true ]; then
@@ -205,6 +215,8 @@ if ! maintenance validate || ! maintenance artifacts "${artifact_baseline}"; the
   rollback || true
   fail "post-cutover database or runtime-artifact validation failed"
 fi
+
+"${sync_bin}" --finalize "${input_manifest}"
 
 if [ "${old_exists}" = true ]; then
   "${docker_bin}" rm "${previous_name}" >/dev/null

--- a/bin/deploy-local.sh
+++ b/bin/deploy-local.sh
@@ -119,18 +119,25 @@ backup_path=$(printf '%s\n' "${backup_output}" \
 
 echo "Synchronizing source-managed production inputs..."
 input_manifest="${state_root}/data/deployment-inputs-${revision}-$$.json"
+rollback_inputs() {
+  [ ! -f "${input_manifest}" ] \
+    || "${sync_bin}" --rollback "${input_manifest}" "${source_root}" "${state_root}" "${config_file}"
+}
 if ! sync_output=$("${sync_bin}" "${source_root}" "${state_root}" "${config_file}" "${input_manifest}"); then
+  if ! rollback_inputs; then
+    fail "source-managed input synchronization and rollback failed; prior container remains stopped: ${input_manifest}"
+  fi
   if [ "${old_running}" = true ]; then "${docker_bin}" start "${container_name}" >/dev/null; fi
   fail "source-managed input synchronization failed"
 fi
 echo "${sync_output}"
 if [ ! -f "${config_file}" ]; then
-  "${sync_bin}" --rollback "${input_manifest}" "${source_root}" "${state_root}" "${config_file}" || true
+  rollback_inputs || fail "configuration validation and source-input rollback failed; prior container remains stopped: ${input_manifest}"
   if [ "${old_running}" = true ]; then "${docker_bin}" start "${container_name}" >/dev/null; fi
   fail "production configuration was not created"
 fi
 if ! maintenance validate || ! maintenance artifacts "${artifact_baseline}"; then
-  "${sync_bin}" --rollback "${input_manifest}" "${source_root}" "${state_root}" "${config_file}" || true
+  rollback_inputs || fail "integrity validation and source-input rollback failed; prior container remains stopped: ${input_manifest}"
   if [ "${old_running}" = true ]; then "${docker_bin}" start "${container_name}" >/dev/null; fi
   fail "source synchronization introduced an integrity regression"
 fi

--- a/docs/architecture/decisions/0007-immutable-production-deployment.md
+++ b/docs/architecture/decisions/0007-immutable-production-deployment.md
@@ -29,13 +29,14 @@ flowchart LR
 - Production deploys that exact Docker image without rebuilding it locally.
 - Databases, documents, configuration, logs, backups, and credentials remain
   outside the Docker image in operator-managed locations.
-- Before cutover, deployment creates and verifies a database backup, runs
-  migrations with the new Docker image, and requires integrity and foreign-key
-  validation.
+- Before cutover, deployment stops runtime writes; creates and verifies a
+  coupled SQLite-and-runtime-artifact snapshot; runs migrations with the new
+  Docker image; and requires database and registered-artifact validation.
 - The replacement must report healthy at the requested revision before the
   previous container is removed.
-- Migration, startup, or health failure restores the backup and prior
-  container. Bypassing this verified deployment path is unsupported.
+- Migration, startup, health, or post-cutover integrity failure restores the
+  matching database and artifact snapshot with the prior container. Bypassing
+  this verified deployment path is unsupported.
 
 ## Consequences
 
@@ -43,6 +44,6 @@ flowchart LR
   image.
 - Pull-request validation and release publication share the same build path.
 - Private state cannot enter source or build artifacts.
-- Database and application rollback remain coupled.
+- Database, runtime-artifact, and application rollback remain coupled.
 - Deployment depends on Docker registry availability and maintained external
   state, backup, and credential directories.

--- a/docs/architecture/deployment-runbook.md
+++ b/docs/architecture/deployment-runbook.md
@@ -57,6 +57,13 @@ private context without changing the development database.
 
 ## Deploy
 
+The host deployment script is part of the safety boundary. After a deployment
+script change, merge it first and update the local operator checkout to that
+exact merge. Inspect that the checkout contains the corrected
+`bin/deploy-local.sh` and `bin/sync-production-inputs` before running either
+script. Never use an older checkout to deploy the image containing its own
+deployment fix; the host script runs before the new container exists.
+
 Set `GIG_FINDER_CODEX_HOME` to the host credential directory and deploy the
 exact published merge tag. The script mounts it read-only and sets container
 `CODEX_HOME` to `/run/codex`.
@@ -66,7 +73,16 @@ GIG_FINDER_CODEX_HOME=/absolute/codex/home \
   bin/deploy-local.sh sha-<40-character-commit-sha>
 ```
 
-The script synchronizes private inputs, pulls the Docker image, creates and
-verifies a backup, migrates and validates SQLite, replaces the container, and
-checks `/healthz` for the requested revision. On failure it restores the backup
-and prior container.
+The script pulls the immutable image, stops runtime writes, verifies registered
+artifacts, and creates a matching SQLite-plus-artifact snapshot. It then
+synchronizes only explicitly source-managed inputs, migrates and validates the
+state, replaces the container, checks `/healthz` for the requested revision,
+and validates the state again. On failure it restores the matching database and
+artifact snapshot with the prior container. The previous container and recovery
+snapshot remain until post-cutover validation succeeds.
+
+The artifact report contains counts only; it does not log document content.
+Known missing files are captured as the pre-deployment baseline so the safety
+fix can be released while recovery is incomplete. Every later phase must be no
+worse than that baseline. New missing, mismatched, unsafe, or unregistered Scout
+description paths abort deployment and retain recovery material.

--- a/docs/architecture/infrastructure.md
+++ b/docs/architecture/infrastructure.md
@@ -70,3 +70,17 @@
 
 Production deployment and recovery procedures are documented in the
 [Deployment runbook](deployment-runbook.md).
+
+## Production state ownership
+
+| Path | Owner | Deployment behavior |
+| --- | --- | --- |
+| `/etc/gig-finder/config.json` | Source-managed private input | Atomically synchronized |
+| configured candidate profile | Source-managed private input | Atomically synchronized |
+| `data/migration/0010-meeting-participants.json` | Source-managed migration input | Atomically synchronized when present |
+| `data/*.sqlite` and queue databases | Runtime | Never synchronized from the repository |
+| `artifacts/**`, including `artifacts/gig-scout/**` | Runtime | Never synchronized from the repository; backed up and restored with SQLite |
+| logs and temporary materializations | Generated | Kept outside source synchronization |
+
+An unclassified path is not a deployable source input. Deployment code uses an
+explicit source-input list and must not replace a shared production directory.

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -6,6 +6,7 @@ export * from "./database";
 export * from "./document-store";
 export * from "./errors";
 export * from "./maintenance";
+export * from "./runtime-artifacts";
 export * from "./meeting-migration";
 export * from "./legacy-artifact-migration";
 export * from "./profile-document-files";

--- a/src/data/maintenance.ts
+++ b/src/data/maintenance.ts
@@ -1,6 +1,6 @@
 import type { Database } from "bun:sqlite";
 import { createHash } from "node:crypto";
-import { mkdir, readdir, readFile, rename, stat, unlink, writeFile } from "node:fs/promises";
+import { mkdir, readdir, readFile, rename, rm, stat, unlink, writeFile } from "node:fs/promises";
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { openDatabase } from "./database";
@@ -158,6 +158,8 @@ export async function pruneManagedBackups(backupRoot:string,retain=30){
   for(const filename of valid.slice(retain)){
     await unlink(filename);
     await unlink(manifestPath(filename));
+    await rm(`${filename}.artifacts`,{recursive:true,force:true});
+    await rm(`${filename}.state.json`,{force:true});
     pruned.push(filename);
   }
   return pruned;

--- a/src/data/runtime-artifacts.ts
+++ b/src/data/runtime-artifacts.ts
@@ -11,7 +11,15 @@ export interface RuntimeArtifactIntegrity {
   hashMismatched: number;
   unsafe: number;
   unregistered: number;
+  missingFingerprint: string;
+  hashMismatchedFingerprint: string;
+  unsafeFingerprint: string;
+  unregisteredFingerprint: string;
 }
+
+const fingerprint = (values: string[]) => createHash("sha256")
+  .update(values.sort().join("\n"))
+  .digest("hex");
 
 export function hasRuntimeArtifactRegression(
   baseline: RuntimeArtifactIntegrity,
@@ -20,7 +28,11 @@ export function hasRuntimeArtifactRegression(
   return current.missing > baseline.missing
     || current.hashMismatched > baseline.hashMismatched
     || current.unsafe > baseline.unsafe
-    || current.unregistered > baseline.unregistered;
+    || current.unregistered > baseline.unregistered
+    || (current.missing === baseline.missing && current.missingFingerprint !== baseline.missingFingerprint)
+    || (current.hashMismatched === baseline.hashMismatched && current.hashMismatchedFingerprint !== baseline.hashMismatchedFingerprint)
+    || (current.unsafe === baseline.unsafe && current.unsafeFingerprint !== baseline.unsafeFingerprint)
+    || (current.unregistered === baseline.unregistered && current.unregisteredFingerprint !== baseline.unregisteredFingerprint);
 }
 
 interface RegisteredArtifact {
@@ -67,10 +79,14 @@ export async function verifyRuntimeArtifacts(
   let missing = 0;
   let hashMismatched = 0;
   let unsafe = 0;
+  const missingPaths: string[] = [];
+  const mismatchedPaths: string[] = [];
+  const unsafePaths: string[] = [];
 
   for (const artifact of registered) {
     if (!safeRelativePath(artifact.filePath)) {
       unsafe += 1;
+      unsafePaths.push(artifact.filePath);
       continue;
     }
     registeredPaths.add(path.normalize(artifact.filePath));
@@ -81,19 +97,22 @@ export async function verifyRuntimeArtifacts(
     });
     if (!info || !info.isFile()) {
       missing += 1;
+      missingPaths.push(artifact.filePath);
       continue;
     }
     const contents = await readFile(filename);
     const hash = createHash("sha256").update(contents).digest("hex");
     if (contents.byteLength !== artifact.byteCount || hash !== artifact.contentHash) {
       hashMismatched += 1;
+      mismatchedPaths.push(artifact.filePath);
       continue;
     }
     present += 1;
   }
 
   const diskFiles = await filesBelow(scoutDescriptionsRoot);
-  const unregistered = diskFiles.filter((filename) => !registeredPaths.has(path.normalize(filename))).length;
+  const unregisteredPaths = diskFiles.filter((filename) => !registeredPaths.has(path.normalize(filename)));
+  const unregistered = unregisteredPaths.length;
   return {
     ok: missing === 0 && hashMismatched === 0 && unsafe === 0,
     registered: registered.length,
@@ -102,5 +121,9 @@ export async function verifyRuntimeArtifacts(
     hashMismatched,
     unsafe,
     unregistered,
+    missingFingerprint: fingerprint(missingPaths),
+    hashMismatchedFingerprint: fingerprint(mismatchedPaths),
+    unsafeFingerprint: fingerprint(unsafePaths),
+    unregisteredFingerprint: fingerprint(unregisteredPaths),
   };
 }

--- a/src/data/runtime-artifacts.ts
+++ b/src/data/runtime-artifacts.ts
@@ -15,11 +15,22 @@ export interface RuntimeArtifactIntegrity {
   hashMismatchedFingerprint: string;
   unsafeFingerprint: string;
   unregisteredFingerprint: string;
+  missingPathHashes: string[];
+  hashMismatchedPathHashes: string[];
+  unsafePathHashes: string[];
+  unregisteredPathHashes: string[];
 }
 
 const fingerprint = (values: string[]) => createHash("sha256")
   .update(values.sort().join("\n"))
   .digest("hex");
+const pathHashes = (values: string[]) => values
+  .map((value) => createHash("sha256").update(value).digest("hex"))
+  .sort();
+const introducesPath = (baseline: string[], current: string[]) => {
+  const known = new Set(baseline);
+  return current.some((value) => !known.has(value));
+};
 
 export function hasRuntimeArtifactRegression(
   baseline: RuntimeArtifactIntegrity,
@@ -29,10 +40,10 @@ export function hasRuntimeArtifactRegression(
     || current.hashMismatched > baseline.hashMismatched
     || current.unsafe > baseline.unsafe
     || current.unregistered > baseline.unregistered
-    || (current.missing === baseline.missing && current.missingFingerprint !== baseline.missingFingerprint)
-    || (current.hashMismatched === baseline.hashMismatched && current.hashMismatchedFingerprint !== baseline.hashMismatchedFingerprint)
-    || (current.unsafe === baseline.unsafe && current.unsafeFingerprint !== baseline.unsafeFingerprint)
-    || (current.unregistered === baseline.unregistered && current.unregisteredFingerprint !== baseline.unregisteredFingerprint);
+    || introducesPath(baseline.missingPathHashes, current.missingPathHashes)
+    || introducesPath(baseline.hashMismatchedPathHashes, current.hashMismatchedPathHashes)
+    || introducesPath(baseline.unsafePathHashes, current.unsafePathHashes)
+    || introducesPath(baseline.unregisteredPathHashes, current.unregisteredPathHashes);
 }
 
 interface RegisteredArtifact {
@@ -125,5 +136,9 @@ export async function verifyRuntimeArtifacts(
     hashMismatchedFingerprint: fingerprint(mismatchedPaths),
     unsafeFingerprint: fingerprint(unsafePaths),
     unregisteredFingerprint: fingerprint(unregisteredPaths),
+    missingPathHashes: pathHashes(missingPaths),
+    hashMismatchedPathHashes: pathHashes(mismatchedPaths),
+    unsafePathHashes: pathHashes(unsafePaths),
+    unregisteredPathHashes: pathHashes(unregisteredPaths),
   };
 }

--- a/src/data/runtime-artifacts.ts
+++ b/src/data/runtime-artifacts.ts
@@ -1,0 +1,106 @@
+import type { Database } from "bun:sqlite";
+import { createHash } from "node:crypto";
+import { lstat, readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+
+export interface RuntimeArtifactIntegrity {
+  ok: boolean;
+  registered: number;
+  present: number;
+  missing: number;
+  hashMismatched: number;
+  unsafe: number;
+  unregistered: number;
+}
+
+export function hasRuntimeArtifactRegression(
+  baseline: RuntimeArtifactIntegrity,
+  current: RuntimeArtifactIntegrity,
+) {
+  return current.missing > baseline.missing
+    || current.hashMismatched > baseline.hashMismatched
+    || current.unsafe > baseline.unsafe
+    || current.unregistered > baseline.unregistered;
+}
+
+interface RegisteredArtifact {
+  filePath: string;
+  contentHash: string;
+  byteCount: number;
+}
+
+function safeRelativePath(value: string) {
+  if (!value || path.isAbsolute(value)) return false;
+  const normalized = path.normalize(value);
+  return normalized !== ".." && !normalized.startsWith(`..${path.sep}`);
+}
+
+async function filesBelow(root: string, relative = ""): Promise<string[]> {
+  const directory = path.join(root, relative);
+  const entries = await readdir(directory, { withFileTypes: true }).catch((error) => {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") return [];
+    throw error;
+  });
+  const files: string[] = [];
+  for (const entry of entries) {
+    const child = path.join(relative, entry.name);
+    if (entry.isDirectory()) files.push(...await filesBelow(root, child));
+    else if (entry.isFile()) files.push(child);
+  }
+  return files;
+}
+
+export async function verifyRuntimeArtifacts(
+  database: Database,
+  scoutDescriptionsRoot: string,
+): Promise<RuntimeArtifactIntegrity> {
+  const table = database.query(
+    "SELECT 1 FROM sqlite_master WHERE type='table' AND name='scout_description_artifacts'",
+  ).get();
+  const registered = table
+    ? database.query(
+      "SELECT file_path filePath, content_hash contentHash, byte_count byteCount FROM scout_description_artifacts ORDER BY file_path",
+    ).all() as RegisteredArtifact[]
+    : [];
+  const registeredPaths = new Set<string>();
+  let present = 0;
+  let missing = 0;
+  let hashMismatched = 0;
+  let unsafe = 0;
+
+  for (const artifact of registered) {
+    if (!safeRelativePath(artifact.filePath)) {
+      unsafe += 1;
+      continue;
+    }
+    registeredPaths.add(path.normalize(artifact.filePath));
+    const filename = path.join(scoutDescriptionsRoot, artifact.filePath);
+    const info = await lstat(filename).catch((error) => {
+      if (error instanceof Error && "code" in error && error.code === "ENOENT") return null;
+      throw error;
+    });
+    if (!info || !info.isFile()) {
+      missing += 1;
+      continue;
+    }
+    const contents = await readFile(filename);
+    const hash = createHash("sha256").update(contents).digest("hex");
+    if (contents.byteLength !== artifact.byteCount || hash !== artifact.contentHash) {
+      hashMismatched += 1;
+      continue;
+    }
+    present += 1;
+  }
+
+  const diskFiles = await filesBelow(scoutDescriptionsRoot);
+  const unregistered = diskFiles.filter((filename) => !registeredPaths.has(path.normalize(filename))).length;
+  return {
+    ok: missing === 0 && hashMismatched === 0 && unsafe === 0,
+    registered: registered.length,
+    present,
+    missing,
+    hashMismatched,
+    unsafe,
+    unregistered,
+  };
+}

--- a/src/data/test/deployment-script.test.ts
+++ b/src/data/test/deployment-script.test.ts
@@ -162,15 +162,17 @@ describe("local production deployment", () => {
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toContain("Deployment complete");
     const pull = result.log.indexOf(`pull ghcr.io/paulmccallick/gig-finder:sha-${revision}`);
+    const preflightValidate = result.log.indexOf("maintenance.js validate");
     const backup = result.log.indexOf("maintenance.js backup");
     const migrate = result.log.indexOf("maintenance.js migrate");
-    const validate = result.log.indexOf("maintenance.js validate");
+    const migrationValidate = result.log.indexOf("maintenance.js validate", migrate);
     const start = result.log.indexOf("run --detach");
-    expect([pull, backup, migrate, validate, start].every((position) => position >= 0)).toBe(true);
+    expect([pull, preflightValidate, backup, migrate, migrationValidate, start].every((position) => position >= 0)).toBe(true);
     expect(pull).toBeLessThan(backup);
+    expect(preflightValidate).toBeLessThan(backup);
     expect(backup).toBeLessThan(migrate);
-    expect(migrate).toBeLessThan(validate);
-    expect(validate).toBeLessThan(start);
+    expect(migrate).toBeLessThan(migrationValidate);
+    expect(migrationValidate).toBeLessThan(start);
     expect(result.log).toContain(
       "-v " + result.productionRoot + ":/var/lib/gig-finder",
     );

--- a/src/data/test/deployment-script.test.ts
+++ b/src/data/test/deployment-script.test.ts
@@ -187,7 +187,7 @@ describe("local production deployment", () => {
     );
     expect(result.log).not.toContain("-v " + result.configFile + ":/etc/gig-finder/config.json:ro");
     expect(result.syncLog).toContain(result.productionRoot);
-    expect(result.syncLog).toContain("--finalize /var/lib/gig-finder/data/deployment-inputs-test.json");
+    expect(result.syncLog).toMatch(/--finalize .*\/data\/deployment-inputs-a{40}-\d+\.json/);
     expect(result.log).toContain("-v " + path.join(directory, "codex") + ":/run/codex:ro");
     expect(result.stdout + result.stderr).not.toContain(path.join(directory, "codex"));
   });
@@ -201,7 +201,7 @@ describe("local production deployment", () => {
     expect(result.log).toContain("maintenance.js restore /var/backups/gig-finder/test.sqlite");
     expect(result.log).toContain("start gig-finder");
     expect(result.log).not.toContain("run --detach");
-    expect(result.syncLog).toContain("--rollback /var/lib/gig-finder/data/deployment-inputs-test.json");
+    expect(result.syncLog).toMatch(/--rollback .*\/data\/deployment-inputs-a{40}-\d+\.json/);
   });
 
   test("restores the backup and prior container when health verification fails", async () => {
@@ -212,6 +212,6 @@ describe("local production deployment", () => {
     expect(result.log).toContain("maintenance.js restore /var/backups/gig-finder/test.sqlite");
     expect(result.log).toContain("rename gig-finder-previous-");
     expect(result.log).toContain("start gig-finder");
-    expect(result.syncLog).toContain("--rollback /var/lib/gig-finder/data/deployment-inputs-test.json");
+    expect(result.syncLog).toMatch(/--rollback .*\/data\/deployment-inputs-a{40}-\d+\.json/);
   });
 });

--- a/src/data/test/deployment-script.test.ts
+++ b/src/data/test/deployment-script.test.ts
@@ -54,6 +54,10 @@ exit 0
 const fakeSync = `#!/bin/sh
 set -eu
 printf '%s\n' "$*" >> "$FAKE_SYNC_LOG"
+case "\${1:-}" in
+  --rollback|--finalize) echo '{"ok":true}' ;;
+  *) echo '{"plan":{"transactionManifest":"/var/lib/gig-finder/data/deployment-inputs-test.json"}}' ;;
+esac
 `;
 
 async function runDeployment(options: {
@@ -183,6 +187,7 @@ describe("local production deployment", () => {
     );
     expect(result.log).not.toContain("-v " + result.configFile + ":/etc/gig-finder/config.json:ro");
     expect(result.syncLog).toContain(result.productionRoot);
+    expect(result.syncLog).toContain("--finalize /var/lib/gig-finder/data/deployment-inputs-test.json");
     expect(result.log).toContain("-v " + path.join(directory, "codex") + ":/run/codex:ro");
     expect(result.stdout + result.stderr).not.toContain(path.join(directory, "codex"));
   });
@@ -196,6 +201,7 @@ describe("local production deployment", () => {
     expect(result.log).toContain("maintenance.js restore /var/backups/gig-finder/test.sqlite");
     expect(result.log).toContain("start gig-finder");
     expect(result.log).not.toContain("run --detach");
+    expect(result.syncLog).toContain("--rollback /var/lib/gig-finder/data/deployment-inputs-test.json");
   });
 
   test("restores the backup and prior container when health verification fails", async () => {
@@ -206,5 +212,6 @@ describe("local production deployment", () => {
     expect(result.log).toContain("maintenance.js restore /var/backups/gig-finder/test.sqlite");
     expect(result.log).toContain("rename gig-finder-previous-");
     expect(result.log).toContain("start gig-finder");
+    expect(result.syncLog).toContain("--rollback /var/lib/gig-finder/data/deployment-inputs-test.json");
   });
 });

--- a/src/data/test/runtime-artifacts.test.ts
+++ b/src/data/test/runtime-artifacts.test.ts
@@ -14,10 +14,11 @@ beforeEach(async () => {
 });
 
 test("allows known damage but rejects a newly worse artifact inventory", () => {
-  const baseline = { ok: false, registered: 3, present: 1, missing: 2, hashMismatched: 0, unsafe: 0, unregistered: 0 };
+  const baseline = { ok: false, registered: 3, present: 1, missing: 2, hashMismatched: 0, unsafe: 0, unregistered: 0, missingFingerprint: "same", hashMismatchedFingerprint: "same", unsafeFingerprint: "same", unregisteredFingerprint: "same" };
   expect(hasRuntimeArtifactRegression(baseline, { ...baseline, present: 2, missing: 1 })).toBe(false);
   expect(hasRuntimeArtifactRegression(baseline, { ...baseline, missing: 3 })).toBe(true);
   expect(hasRuntimeArtifactRegression(baseline, { ...baseline, unregistered: 1 })).toBe(true);
+  expect(hasRuntimeArtifactRegression(baseline, { ...baseline, missingFingerprint: "different" })).toBe(true);
 });
 
 afterEach(async () => {
@@ -37,7 +38,7 @@ test("reports Scout artifact integrity without exposing contents", async () => {
   database.query("INSERT INTO scout_description_artifacts VALUES (?, ?, ?)").run("missing.md", hash, Buffer.byteLength(content));
   database.query("INSERT INTO scout_description_artifacts VALUES (?, ?, ?)").run("../unsafe.md", hash, Buffer.byteLength(content));
 
-  expect(await verifyRuntimeArtifacts(database, descriptions)).toEqual({
+  expect(await verifyRuntimeArtifacts(database, descriptions)).toEqual(expect.objectContaining({
     ok: false,
     registered: 3,
     present: 1,
@@ -45,6 +46,6 @@ test("reports Scout artifact integrity without exposing contents", async () => {
     hashMismatched: 0,
     unsafe: 1,
     unregistered: 1,
-  });
+  }));
   database.close();
 });

--- a/src/data/test/runtime-artifacts.test.ts
+++ b/src/data/test/runtime-artifacts.test.ts
@@ -14,11 +14,11 @@ beforeEach(async () => {
 });
 
 test("allows known damage but rejects a newly worse artifact inventory", () => {
-  const baseline = { ok: false, registered: 3, present: 1, missing: 2, hashMismatched: 0, unsafe: 0, unregistered: 0, missingFingerprint: "same", hashMismatchedFingerprint: "same", unsafeFingerprint: "same", unregisteredFingerprint: "same" };
+  const baseline = { ok: false, registered: 3, present: 1, missing: 2, hashMismatched: 0, unsafe: 0, unregistered: 0, missingFingerprint: "same", hashMismatchedFingerprint: "same", unsafeFingerprint: "same", unregisteredFingerprint: "same", missingPathHashes: ["a", "b"], hashMismatchedPathHashes: [], unsafePathHashes: [], unregisteredPathHashes: [] };
   expect(hasRuntimeArtifactRegression(baseline, { ...baseline, present: 2, missing: 1 })).toBe(false);
   expect(hasRuntimeArtifactRegression(baseline, { ...baseline, missing: 3 })).toBe(true);
   expect(hasRuntimeArtifactRegression(baseline, { ...baseline, unregistered: 1 })).toBe(true);
-  expect(hasRuntimeArtifactRegression(baseline, { ...baseline, missingFingerprint: "different" })).toBe(true);
+  expect(hasRuntimeArtifactRegression(baseline, { ...baseline, missing: 1, missingPathHashes: ["c"] })).toBe(true);
 });
 
 afterEach(async () => {

--- a/src/data/test/runtime-artifacts.test.ts
+++ b/src/data/test/runtime-artifacts.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { openDatabase } from "../database";
+import { hasRuntimeArtifactRegression, verifyRuntimeArtifacts } from "../runtime-artifacts";
+
+const temporaryRoot = path.resolve("tmp");
+let directory = "";
+
+beforeEach(async () => {
+  await mkdir(temporaryRoot, { recursive: true });
+  directory = await mkdtemp(path.join(temporaryRoot, "runtime-artifacts-"));
+});
+
+test("allows known damage but rejects a newly worse artifact inventory", () => {
+  const baseline = { ok: false, registered: 3, present: 1, missing: 2, hashMismatched: 0, unsafe: 0, unregistered: 0 };
+  expect(hasRuntimeArtifactRegression(baseline, { ...baseline, present: 2, missing: 1 })).toBe(false);
+  expect(hasRuntimeArtifactRegression(baseline, { ...baseline, missing: 3 })).toBe(true);
+  expect(hasRuntimeArtifactRegression(baseline, { ...baseline, unregistered: 1 })).toBe(true);
+});
+
+afterEach(async () => {
+  await rm(directory, { recursive: true, force: true });
+});
+
+test("reports Scout artifact integrity without exposing contents", async () => {
+  const database = openDatabase(path.join(directory, "database.sqlite"));
+  const descriptions = path.join(directory, "artifacts", "gig-scout", "descriptions");
+  const content = "synthetic description\n";
+  const hash = createHash("sha256").update(content).digest("hex");
+  await mkdir(path.join(descriptions, "aa"), { recursive: true });
+  await writeFile(path.join(descriptions, "aa", "present.md"), content);
+  await writeFile(path.join(descriptions, "unregistered.md"), "extra\n");
+  database.exec("CREATE TABLE scout_description_artifacts(file_path text, content_hash text, byte_count integer)");
+  database.query("INSERT INTO scout_description_artifacts VALUES (?, ?, ?)").run("aa/present.md", hash, Buffer.byteLength(content));
+  database.query("INSERT INTO scout_description_artifacts VALUES (?, ?, ?)").run("missing.md", hash, Buffer.byteLength(content));
+  database.query("INSERT INTO scout_description_artifacts VALUES (?, ?, ?)").run("../unsafe.md", hash, Buffer.byteLength(content));
+
+  expect(await verifyRuntimeArtifacts(database, descriptions)).toEqual({
+    ok: false,
+    registered: 3,
+    present: 1,
+    missing: 1,
+    hashMismatched: 0,
+    unsafe: 1,
+    unregistered: 1,
+  });
+  database.close();
+});

--- a/src/operations/bootstrap-context.ts
+++ b/src/operations/bootstrap-context.ts
@@ -67,6 +67,16 @@ export async function copyContext(
     backupRoot,
   );
   const database = await createVerifiedBackup(source.database, targetDatabase);
+  try {
+    await stat(source.artifacts);
+    await cp(source.artifacts, path.join(targetRoot, "artifacts"), {
+      recursive: true,
+      errorOnExist: true,
+      force: false,
+    });
+  } catch (error) {
+    if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) throw error;
+  }
   const inputs = await syncProductionInputs(
     sourceRoot,
     targetRoot,

--- a/src/operations/maintenance.ts
+++ b/src/operations/maintenance.ts
@@ -1,7 +1,8 @@
 import path from "node:path";
-import { mkdir } from "node:fs/promises";
+import { cp, mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import {
   createManagedBackup,
+  hasRuntimeArtifactRegression,
   loadLegacyMeetingParticipants,
   migrateLegacyGigArtifacts,
   migrateDatabase,
@@ -9,6 +10,7 @@ import {
   resolveGigFinderContext,
   restoreVerifiedBackup,
   validateDatabase,
+  verifyRuntimeArtifacts,
 } from "../data";
 
 const repoRoot = path.resolve(import.meta.dir, "../..");
@@ -17,9 +19,76 @@ const [command, argument] = process.argv.slice(2);
 
 const output = (value: unknown) => console.log(JSON.stringify(value));
 
+const artifactSnapshotPath = (databaseBackupPath: string) => `${databaseBackupPath}.artifacts`;
+const stateManifestPath = (databaseBackupPath: string) => `${databaseBackupPath}.state.json`;
+
+async function artifactIntegrity() {
+  const database = openDatabase(context.database, { create: false });
+  try {
+    return await verifyRuntimeArtifacts(database, context.scoutDescriptions);
+  } finally {
+    database.close();
+  }
+}
+
+async function createArtifactSnapshot(databaseBackupPath: string) {
+  const integrity = await artifactIntegrity();
+  const target = artifactSnapshotPath(databaseBackupPath);
+  const temporary = `${target}.tmp-${process.pid}-${Date.now()}`;
+  try {
+    await cp(context.artifacts, temporary, { recursive: true, errorOnExist: true, force: false });
+    await rename(temporary, target);
+  } finally {
+    await rm(temporary, { recursive: true, force: true });
+  }
+  const backupDatabase = openDatabase(databaseBackupPath, { create: false });
+  let snapshotIntegrity;
+  try {
+    snapshotIntegrity = await verifyRuntimeArtifacts(
+      backupDatabase,
+      path.join(target, "gig-scout", "descriptions"),
+    );
+  } finally {
+    backupDatabase.close();
+  }
+  if (JSON.stringify(snapshotIntegrity) !== JSON.stringify(integrity)) {
+    await rm(target, { recursive: true, force: true });
+    throw new Error("Artifact snapshot does not match the pre-backup integrity inventory.");
+  }
+  const manifest = { version: 1, databaseBackupPath, artifactSnapshotPath: target, integrity: snapshotIntegrity };
+  await writeFile(stateManifestPath(databaseBackupPath), `${JSON.stringify(manifest, null, 2)}\n`, { flag: "wx" });
+  return { path: target, integrity: snapshotIntegrity };
+}
+
+async function restoreArtifactSnapshot(databaseBackupPath: string) {
+  const source = artifactSnapshotPath(databaseBackupPath);
+  const manifest = JSON.parse(await readFile(stateManifestPath(databaseBackupPath), "utf8")) as {
+    version: number;
+    artifactSnapshotPath: string;
+  };
+  if (manifest.version !== 1 || manifest.artifactSnapshotPath !== source) {
+    throw new Error("Backup state manifest does not match the requested database backup.");
+  }
+  const temporary = `${context.artifacts}.restore-${process.pid}-${Date.now()}`;
+  const displaced = `${context.artifacts}.pre-restore-${process.pid}-${Date.now()}`;
+  await cp(source, temporary, { recursive: true, errorOnExist: true, force: false });
+  await rename(context.artifacts, displaced);
+  try {
+    await rename(temporary, context.artifacts);
+    await rm(displaced, { recursive: true, force: true });
+  } catch (error) {
+    await rm(context.artifacts, { recursive: true, force: true });
+    await rename(displaced, context.artifacts);
+    throw error;
+  } finally {
+    await rm(temporary, { recursive: true, force: true });
+  }
+}
+
 if (command === "backup") {
   const backup = await createManagedBackup(context.database, context.backups);
-  output({ command, ok: true, backup });
+  const artifacts = await createArtifactSnapshot(backup.path);
+  output({ command, ok: true, backup, artifacts });
 } else if (command === "migrate" || command === "initialize") {
   if (command === "initialize") {
     await mkdir(path.dirname(context.database), { recursive: true });
@@ -42,7 +111,8 @@ if (command === "backup") {
   const database = openDatabase(context.database, { create: false });
   try {
     const validation = validateDatabase(database);
-    output({ command, ok: validation.ok, validation });
+    const artifacts = await verifyRuntimeArtifacts(database, context.scoutDescriptions);
+    output({ command, ok: validation.ok, validation, artifacts });
     if (!validation.ok) process.exitCode = 1;
   } finally {
     database.close();
@@ -56,7 +126,26 @@ if (command === "backup") {
     argument,
     context.backups,
   );
-  output({ command, ok: true, ...restored });
+  await restoreArtifactSnapshot(argument);
+  const artifacts = await artifactIntegrity();
+  const manifest = JSON.parse(await readFile(stateManifestPath(argument), "utf8")) as {
+    integrity: unknown;
+  };
+  if (JSON.stringify(artifacts) !== JSON.stringify(manifest.integrity)) {
+    throw new Error("Restored runtime artifact inventory does not match its backup manifest.");
+  }
+  output({ command, ok: true, ...restored, artifacts });
+} else if (command === "artifacts") {
+  const artifacts = await artifactIntegrity();
+  if (argument) {
+    const parsed = JSON.parse(argument) as typeof artifacts | { artifacts: typeof artifacts };
+    const baseline = "artifacts" in parsed ? parsed.artifacts : parsed;
+    const regression = hasRuntimeArtifactRegression(baseline, artifacts);
+    output({ command, ok: !regression, artifacts, baseline });
+    if (regression) process.exitCode = 1;
+  } else {
+    output({ command, ok: true, artifacts });
+  }
 } else {
-  throw new Error("Usage: maintenance <backup|initialize|migrate|validate|restore> [backup-path]");
+  throw new Error("Usage: maintenance <artifacts|backup|initialize|migrate|validate|restore> [argument]");
 }

--- a/src/operations/maintenance.ts
+++ b/src/operations/maintenance.ts
@@ -60,11 +60,12 @@ async function createArtifactSnapshot(databaseBackupPath: string) {
   return { path: target, integrity: snapshotIntegrity };
 }
 
-async function restoreArtifactSnapshot(databaseBackupPath: string) {
+async function activateArtifactSnapshot(databaseBackupPath: string) {
   const source = artifactSnapshotPath(databaseBackupPath);
   const manifest = JSON.parse(await readFile(stateManifestPath(databaseBackupPath), "utf8")) as {
     version: number;
     artifactSnapshotPath: string;
+    integrity: unknown;
   };
   if (manifest.version !== 1 || manifest.artifactSnapshotPath !== source) {
     throw new Error("Backup state manifest does not match the requested database backup.");
@@ -72,17 +73,34 @@ async function restoreArtifactSnapshot(databaseBackupPath: string) {
   const temporary = `${context.artifacts}.restore-${process.pid}-${Date.now()}`;
   const displaced = `${context.artifacts}.pre-restore-${process.pid}-${Date.now()}`;
   await cp(source, temporary, { recursive: true, errorOnExist: true, force: false });
+  const backupDatabase = openDatabase(databaseBackupPath, { create: false });
+  try {
+    const staged = await verifyRuntimeArtifacts(
+      backupDatabase,
+      path.join(temporary, "gig-scout", "descriptions"),
+    );
+    if (JSON.stringify(staged) !== JSON.stringify(manifest.integrity)) {
+      throw new Error("Staged runtime artifacts do not match the backup state manifest.");
+    }
+  } finally {
+    backupDatabase.close();
+  }
   await rename(context.artifacts, displaced);
   try {
     await rename(temporary, context.artifacts);
-    await rm(displaced, { recursive: true, force: true });
   } catch (error) {
-    await rm(context.artifacts, { recursive: true, force: true });
     await rename(displaced, context.artifacts);
     throw error;
   } finally {
     await rm(temporary, { recursive: true, force: true });
   }
+  return {
+    finalize: () => rm(displaced, { recursive: true, force: true }),
+    rollback: async () => {
+      await rm(context.artifacts, { recursive: true, force: true });
+      await rename(displaced, context.artifacts);
+    },
+  };
 }
 
 if (command === "backup") {
@@ -121,20 +139,31 @@ if (command === "backup") {
   if (!argument || !path.isAbsolute(argument)) {
     throw new Error("restore requires an absolute managed-backup path.");
   }
-  const restored = await restoreVerifiedBackup(
-    context.database,
-    argument,
-    context.backups,
-  );
-  await restoreArtifactSnapshot(argument);
-  const artifacts = await artifactIntegrity();
-  const manifest = JSON.parse(await readFile(stateManifestPath(argument), "utf8")) as {
-    integrity: unknown;
-  };
-  if (JSON.stringify(artifacts) !== JSON.stringify(manifest.integrity)) {
-    throw new Error("Restored runtime artifact inventory does not match its backup manifest.");
+  const activatedArtifacts = await activateArtifactSnapshot(argument);
+  let preRestoreDatabase: string | null = null;
+  try {
+    const restored = await restoreVerifiedBackup(
+      context.database,
+      argument,
+      context.backups,
+    );
+    preRestoreDatabase = restored.preRestore.path;
+    const artifacts = await artifactIntegrity();
+    const manifest = JSON.parse(await readFile(stateManifestPath(argument), "utf8")) as {
+      integrity: unknown;
+    };
+    if (JSON.stringify(artifacts) !== JSON.stringify(manifest.integrity)) {
+      throw new Error("Restored runtime artifact inventory does not match its backup manifest.");
+    }
+    await activatedArtifacts.finalize();
+    output({ command, ok: true, ...restored, artifacts });
+  } catch (error) {
+    if (preRestoreDatabase) {
+      await restoreVerifiedBackup(context.database, preRestoreDatabase, context.backups);
+    }
+    await activatedArtifacts.rollback();
+    throw error;
   }
-  output({ command, ok: true, ...restored, artifacts });
 } else if (command === "artifacts") {
   const artifacts = await artifactIntegrity();
   if (argument) {

--- a/src/operations/maintenance.ts
+++ b/src/operations/maintenance.ts
@@ -95,7 +95,7 @@ async function activateArtifactSnapshot(databaseBackupPath: string) {
     await rm(temporary, { recursive: true, force: true });
   }
   return {
-    finalize: () => rm(displaced, { recursive: true, force: true }),
+    finalize: () => rm(displaced, { recursive: true, force: true }).catch(() => undefined),
     rollback: async () => {
       await rm(context.artifacts, { recursive: true, force: true });
       await rename(displaced, context.artifacts);

--- a/src/operations/production-inputs.ts
+++ b/src/operations/production-inputs.ts
@@ -84,13 +84,25 @@ async function readInputManifest(manifestPath: string, sourceRoot: string, state
     path.join(stateRoot, profileRelative),
     path.join(stateRoot, "data", "migration", "0010-meeting-participants.json"),
   ]);
+  const seenTargets = new Set<string>();
+  let transactionSuffix: string | null = null;
   for (const entry of parsed.backups) {
     if (!allowedTargets.has(entry.target)) throw new Error("Production input manifest contains an unsafe target.");
-    if (path.dirname(entry.backup) !== path.dirname(entry.target)
-      || !path.basename(entry.backup).startsWith(`${path.basename(entry.target)}.deploy-backup-`)) {
+    if (seenTargets.has(entry.target) || typeof entry.existed !== "boolean") {
+      throw new Error("Production input manifest is incomplete or duplicated.");
+    }
+    seenTargets.add(entry.target);
+    const backupPrefix = `${entry.target}.deploy-backup-`;
+    if (!entry.backup.startsWith(backupPrefix) || path.dirname(entry.backup) !== path.dirname(entry.target)) {
       throw new Error("Production input manifest contains an unsafe recovery path.");
     }
+    const suffix = entry.backup.slice(backupPrefix.length);
+    if (!suffix || (transactionSuffix !== null && suffix !== transactionSuffix)) {
+      throw new Error("Production input manifest contains inconsistent recovery paths.");
+    }
+    transactionSuffix = suffix;
   }
+  if (seenTargets.size !== allowedTargets.size) throw new Error("Production input manifest is incomplete or duplicated.");
   return parsed.backups;
 }
 

--- a/src/operations/production-inputs.ts
+++ b/src/operations/production-inputs.ts
@@ -69,21 +69,39 @@ async function restoreInputs(backups: InputBackup[]) {
   if (failures.length) throw new AggregateError(failures, "Production input rollback failed; recovery copies were retained.");
 }
 
-async function readInputManifest(manifestPath: string) {
+async function readInputManifest(manifestPath: string, sourceRoot: string, stateRoot: string, configTarget: string) {
   if (!path.isAbsolute(manifestPath)) throw new Error("Production input transaction manifest must be absolute.");
+  const manifestRelative = path.relative(path.join(stateRoot, "data"), manifestPath);
+  if (manifestRelative.startsWith("..") || !path.basename(manifestPath).startsWith("deployment-inputs-")) {
+    throw new Error("Production input transaction manifest is outside the production data root.");
+  }
   const parsed = JSON.parse(await readFile(manifestPath, "utf8")) as { version: number; backups: InputBackup[] };
   if (parsed.version !== 1 || !Array.isArray(parsed.backups)) throw new Error("Invalid production input transaction manifest.");
+  const source = resolveGigFinderContext(repositoryRoot, { GIG_FINDER_CONTEXT_ROOT: sourceRoot });
+  const profileRelative = requireDescendant(sourceRoot, source.profile, "Profile");
+  const allowedTargets = new Set([
+    configTarget,
+    path.join(stateRoot, profileRelative),
+    path.join(stateRoot, "data", "migration", "0010-meeting-participants.json"),
+  ]);
+  for (const entry of parsed.backups) {
+    if (!allowedTargets.has(entry.target)) throw new Error("Production input manifest contains an unsafe target.");
+    if (path.dirname(entry.backup) !== path.dirname(entry.target)
+      || !path.basename(entry.backup).startsWith(`${path.basename(entry.target)}.deploy-backup-`)) {
+      throw new Error("Production input manifest contains an unsafe recovery path.");
+    }
+  }
   return parsed.backups;
 }
 
-export async function finalizeProductionInputs(manifestPath: string) {
-  const backups = await readInputManifest(manifestPath);
+export async function finalizeProductionInputs(manifestPath: string, sourceRoot: string, stateRoot: string, configTarget: string) {
+  const backups = await readInputManifest(manifestPath, sourceRoot, stateRoot, configTarget);
   await Promise.all(backups.map(({ backup }) => rm(backup, { force: true })));
   await rm(manifestPath);
 }
 
-export async function rollbackProductionInputs(manifestPath: string) {
-  const backups = await readInputManifest(manifestPath);
+export async function rollbackProductionInputs(manifestPath: string, sourceRoot: string, stateRoot: string, configTarget: string) {
+  const backups = await readInputManifest(manifestPath, sourceRoot, stateRoot, configTarget);
   await restoreInputs(backups);
   await Promise.all(backups.map(({ backup }) => rm(backup, { force: true })));
   await rm(manifestPath);
@@ -94,6 +112,7 @@ export async function syncProductionInputs(
   stateRootArgument: string,
   configFileArgument: string,
   applicationRoot = repositoryRoot,
+  transactionManifestArgument?: string,
 ) {
   if (![sourceRootArgument, stateRootArgument, configFileArgument].every(path.isAbsolute)) {
     throw new Error("Production input paths must be absolute.");
@@ -114,6 +133,13 @@ export async function syncProductionInputs(
   const profileTarget = path.join(stateRoot, profileRelative);
   const migrationTarget = path.join(stateRoot, migrationRelative);
   const backups = await snapshotInputs([configTarget, profileTarget, migrationTarget]);
+  const transactionManifest = transactionManifestArgument
+    ? path.resolve(transactionManifestArgument)
+    : path.join(stateRoot, "data", `deployment-inputs-${randomUUID()}.json`);
+  const manifestRelative = path.relative(path.join(stateRoot, "data"), transactionManifest);
+  if (manifestRelative.startsWith("..")) throw new Error("Production input transaction manifest must be inside the production data root.");
+  await mkdir(path.dirname(transactionManifest), { recursive: true });
+  await writeFile(transactionManifest, `${JSON.stringify({ version: 1, backups }, null, 2)}\n`, { flag: "wx", mode: 0o600 });
   try {
     try {
       await stat(configSource);
@@ -138,6 +164,7 @@ export async function syncProductionInputs(
     try {
       await restoreInputs(backups);
       await Promise.all(backups.map(({ backup }) => rm(backup, { force: true })));
+      await rm(transactionManifest, { force: true });
     } catch (rollbackError) {
       throw new AggregateError(
         [error, rollbackError],
@@ -147,9 +174,6 @@ export async function syncProductionInputs(
     }
     throw error;
   }
-  const transactionManifest = path.join(stateRoot, "data", `deployment-inputs-${randomUUID()}.json`);
-  await mkdir(path.dirname(transactionManifest), { recursive: true });
-  await writeFile(transactionManifest, `${JSON.stringify({ version: 1, backups }, null, 2)}\n`, { flag: "wx", mode: 0o600 });
 
   return {
     profile: path.join(stateRoot, profileRelative),

--- a/src/operations/production-inputs.ts
+++ b/src/operations/production-inputs.ts
@@ -100,6 +100,14 @@ async function readInputManifest(manifestPath: string, sourceRoot: string, state
     if (!suffix || (transactionSuffix !== null && suffix !== transactionSuffix)) {
       throw new Error("Production input manifest contains inconsistent recovery paths.");
     }
+    const backupInfo = await stat(entry.backup).catch((error) => {
+      if (isMissing(error)) return null;
+      throw error;
+    });
+    if (backupInfo && !backupInfo.isFile()) throw new Error("Production input recovery copy is not a regular file.");
+    if (entry.existed !== Boolean(backupInfo)) {
+      throw new Error("Production input manifest existence metadata does not match protected recovery state.");
+    }
     transactionSuffix = suffix;
   }
   if (seenTargets.size !== allowedTargets.size) throw new Error("Production input manifest is incomplete or duplicated.");

--- a/src/operations/production-inputs.ts
+++ b/src/operations/production-inputs.ts
@@ -27,35 +27,6 @@ async function copyFileAtomically(source: string, target: string) {
   }
 }
 
-async function replaceDirectory(source: string, target: string) {
-  await mkdir(path.dirname(target), { recursive: true });
-  const suffix = `${process.pid}-${Date.now()}`;
-  const staging = `${target}.deploy-${suffix}`;
-  const previous = `${target}.previous-${suffix}`;
-  let displaced = false;
-  try {
-    await cp(source, staging, { recursive: true, errorOnExist: true, force: false });
-  } catch (error) {
-    if (!isMissing(error)) throw error;
-    await mkdir(staging, { recursive: true });
-  }
-  try {
-    try {
-      await rename(target, previous);
-      displaced = true;
-    } catch (error) {
-      if (!isMissing(error)) throw error;
-    }
-    await rename(staging, target);
-    if (displaced) await rm(previous, { recursive: true, force: true });
-  } catch (error) {
-    if (displaced) await rename(previous, target).catch(() => undefined);
-    throw error;
-  } finally {
-    await rm(staging, { recursive: true, force: true });
-  }
-}
-
 export async function syncProductionInputs(
   sourceRootArgument: string,
   stateRootArgument: string,
@@ -90,7 +61,6 @@ export async function syncProductionInputs(
   }
 
   await copyFileAtomically(source.profile, path.join(stateRoot, profileRelative));
-  await replaceDirectory(source.artifacts, path.join(stateRoot, "artifacts"));
 
   const migrationRelative = path.join("data", "migration", "0010-meeting-participants.json");
   const migrationSource = path.join(sourceRoot, migrationRelative);
@@ -103,7 +73,11 @@ export async function syncProductionInputs(
 
   return {
     profile: path.join(stateRoot, profileRelative),
-    artifacts: path.join(stateRoot, "artifacts"),
     config: configTarget,
+    plan: {
+      createsOrReplaces: [configTarget, path.join(stateRoot, profileRelative)],
+      runtimeOwnedRoots: [path.join(stateRoot, "artifacts")],
+      prohibitedDeletes: 0,
+    },
   };
 }

--- a/src/operations/production-inputs.ts
+++ b/src/operations/production-inputs.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
-import { chmod, cp, mkdir, realpath, rename, rm, stat, writeFile } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { chmod, cp, mkdir, readFile, realpath, rename, rm, stat, writeFile } from "node:fs/promises";
 import { resolveGigFinderContext } from "../data";
 
 const repositoryRoot = path.resolve(import.meta.dir, "../..");
@@ -56,10 +57,36 @@ async function snapshotInputs(targets: string[]) {
 }
 
 async function restoreInputs(backups: InputBackup[]) {
+  const failures: unknown[] = [];
   for (const { target, backup, existed } of [...backups].reverse()) {
-    if (existed) await rename(backup, target);
-    else await rm(target, { force: true });
+    try {
+      if (existed) await rename(backup, target);
+      else await rm(target, { force: true });
+    } catch (error) {
+      failures.push(error);
+    }
   }
+  if (failures.length) throw new AggregateError(failures, "Production input rollback failed; recovery copies were retained.");
+}
+
+async function readInputManifest(manifestPath: string) {
+  if (!path.isAbsolute(manifestPath)) throw new Error("Production input transaction manifest must be absolute.");
+  const parsed = JSON.parse(await readFile(manifestPath, "utf8")) as { version: number; backups: InputBackup[] };
+  if (parsed.version !== 1 || !Array.isArray(parsed.backups)) throw new Error("Invalid production input transaction manifest.");
+  return parsed.backups;
+}
+
+export async function finalizeProductionInputs(manifestPath: string) {
+  const backups = await readInputManifest(manifestPath);
+  await Promise.all(backups.map(({ backup }) => rm(backup, { force: true })));
+  await rm(manifestPath);
+}
+
+export async function rollbackProductionInputs(manifestPath: string) {
+  const backups = await readInputManifest(manifestPath);
+  await restoreInputs(backups);
+  await Promise.all(backups.map(({ backup }) => rm(backup, { force: true })));
+  await rm(manifestPath);
 }
 
 export async function syncProductionInputs(
@@ -108,11 +135,21 @@ export async function syncProductionInputs(
       if (!isMissing(error)) throw error;
     }
   } catch (error) {
-    await restoreInputs(backups);
+    try {
+      await restoreInputs(backups);
+      await Promise.all(backups.map(({ backup }) => rm(backup, { force: true })));
+    } catch (rollbackError) {
+      throw new AggregateError(
+        [error, rollbackError],
+        "Production input synchronization and rollback failed.",
+        { cause: rollbackError },
+      );
+    }
     throw error;
-  } finally {
-    await Promise.all(backups.map(({ backup }) => rm(backup, { force: true })));
   }
+  const transactionManifest = path.join(stateRoot, "data", `deployment-inputs-${randomUUID()}.json`);
+  await mkdir(path.dirname(transactionManifest), { recursive: true });
+  await writeFile(transactionManifest, `${JSON.stringify({ version: 1, backups }, null, 2)}\n`, { flag: "wx", mode: 0o600 });
 
   return {
     profile: path.join(stateRoot, profileRelative),
@@ -121,6 +158,7 @@ export async function syncProductionInputs(
       createsOrReplaces: [configTarget, path.join(stateRoot, profileRelative)],
       runtimeOwnedRoots: [path.join(stateRoot, "artifacts")],
       prohibitedDeletes: 0,
+      transactionManifest,
     },
   };
 }

--- a/src/operations/production-inputs.ts
+++ b/src/operations/production-inputs.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { cp, mkdir, realpath, rename, rm, stat, writeFile } from "node:fs/promises";
+import { chmod, cp, mkdir, realpath, rename, rm, stat, writeFile } from "node:fs/promises";
 import { resolveGigFinderContext } from "../data";
 
 const repositoryRoot = path.resolve(import.meta.dir, "../..");
@@ -21,9 +21,44 @@ async function copyFileAtomically(source: string, target: string) {
   const temporary = `${target}.deploy-${process.pid}-${Date.now()}`;
   try {
     await cp(source, temporary, { errorOnExist: true, force: false });
+    const existing = await stat(target).catch((error) => {
+      if (isMissing(error)) return null;
+      throw error;
+    });
+    if (existing) await chmod(temporary, existing.mode);
     await rename(temporary, target);
   } finally {
     await rm(temporary, { force: true });
+  }
+}
+
+interface InputBackup { target: string; backup: string; existed: boolean }
+
+async function snapshotInputs(targets: string[]) {
+  const suffix = `${process.pid}-${Date.now()}`;
+  const backups: InputBackup[] = [];
+  try {
+    for (const target of targets) {
+      const backup = `${target}.deploy-backup-${suffix}`;
+      const info = await stat(target).catch((error) => {
+        if (isMissing(error)) return null;
+        throw error;
+      });
+      if (info && !info.isFile()) throw new Error(`Production input target must be a regular file: ${target}`);
+      if (info) await cp(target, backup, { errorOnExist: true, force: false });
+      backups.push({ target, backup, existed: Boolean(info) });
+    }
+    return backups;
+  } catch (error) {
+    await Promise.all(backups.map(({ backup }) => rm(backup, { force: true })));
+    throw error;
+  }
+}
+
+async function restoreInputs(backups: InputBackup[]) {
+  for (const { target, backup, existed } of [...backups].reverse()) {
+    if (existed) await rename(backup, target);
+    else await rm(target, { force: true });
   }
 }
 
@@ -47,28 +82,36 @@ export async function syncProductionInputs(
   const configSource = path.join(sourceRoot, "config.json");
   const configTarget = path.resolve(configFileArgument);
 
-  try {
-    await stat(configSource);
-    await copyFileAtomically(configSource, configTarget);
-  } catch (error) {
-    if (!isMissing(error)) throw error;
-    await mkdir(path.dirname(configTarget), { recursive: true });
-    await writeFile(configTarget, `${JSON.stringify({
-      version: 1,
-      actor: source.actor,
-      profile: profileRelative,
-    }, null, 2)}\n`);
-  }
-
-  await copyFileAtomically(source.profile, path.join(stateRoot, profileRelative));
-
   const migrationRelative = path.join("data", "migration", "0010-meeting-participants.json");
   const migrationSource = path.join(sourceRoot, migrationRelative);
+  const profileTarget = path.join(stateRoot, profileRelative);
+  const migrationTarget = path.join(stateRoot, migrationRelative);
+  const backups = await snapshotInputs([configTarget, profileTarget, migrationTarget]);
   try {
-    await stat(migrationSource);
-    await copyFileAtomically(migrationSource, path.join(stateRoot, migrationRelative));
+    try {
+      await stat(configSource);
+      await copyFileAtomically(configSource, configTarget);
+    } catch (error) {
+      if (!isMissing(error)) throw error;
+      await mkdir(path.dirname(configTarget), { recursive: true });
+      await writeFile(configTarget, `${JSON.stringify({
+        version: 1,
+        actor: source.actor,
+        profile: profileRelative,
+      }, null, 2)}\n`);
+    }
+    await copyFileAtomically(source.profile, profileTarget);
+    try {
+      await stat(migrationSource);
+      await copyFileAtomically(migrationSource, migrationTarget);
+    } catch (error) {
+      if (!isMissing(error)) throw error;
+    }
   } catch (error) {
-    if (!isMissing(error)) throw error;
+    await restoreInputs(backups);
+    throw error;
+  } finally {
+    await Promise.all(backups.map(({ backup }) => rm(backup, { force: true })));
   }
 
   return {

--- a/src/operations/sync-production-context.ts
+++ b/src/operations/sync-production-context.ts
@@ -3,18 +3,20 @@ import { finalizeProductionInputs, rollbackProductionInputs, syncProductionInput
 const [mode, ...arguments_] = process.argv.slice(2);
 
 if (mode === "--finalize" || mode === "--rollback") {
-  const manifest = arguments_[0];
-  if (!manifest) throw new Error(`${mode} requires a transaction manifest.`);
-  if (mode === "--finalize") await finalizeProductionInputs(manifest);
-  else await rollbackProductionInputs(manifest);
+  const [manifest, sourceRoot, stateRoot, configTarget] = arguments_;
+  if (!manifest || !sourceRoot || !stateRoot || !configTarget) {
+    throw new Error(`${mode} requires manifest, source root, state root, and config target.`);
+  }
+  if (mode === "--finalize") await finalizeProductionInputs(manifest, sourceRoot, stateRoot, configTarget);
+  else await rollbackProductionInputs(manifest, sourceRoot, stateRoot, configTarget);
   console.log(JSON.stringify({ ok: true, mode, manifest }));
 } else {
-  const [sourceRoot, stateRoot, configFile] = process.argv.slice(2);
+  const [sourceRoot, stateRoot, configFile, transactionManifest] = process.argv.slice(2);
   if (!sourceRoot || !stateRoot || !configFile) {
     throw new Error("Usage: sync-production-context <source-root> <state-root> <config-file>");
   }
   console.log(JSON.stringify(
-    await syncProductionInputs(sourceRoot, stateRoot, configFile),
+    await syncProductionInputs(sourceRoot, stateRoot, configFile, undefined, transactionManifest),
     null,
     2,
   ));

--- a/src/operations/sync-production-context.ts
+++ b/src/operations/sync-production-context.ts
@@ -1,12 +1,21 @@
-import { syncProductionInputs } from "./production-inputs";
+import { finalizeProductionInputs, rollbackProductionInputs, syncProductionInputs } from "./production-inputs";
 
-const [sourceRoot, stateRoot, configFile] = process.argv.slice(2);
-if (!sourceRoot || !stateRoot || !configFile) {
-  throw new Error("Usage: sync-production-context <source-root> <state-root> <config-file>");
+const [mode, ...arguments_] = process.argv.slice(2);
+
+if (mode === "--finalize" || mode === "--rollback") {
+  const manifest = arguments_[0];
+  if (!manifest) throw new Error(`${mode} requires a transaction manifest.`);
+  if (mode === "--finalize") await finalizeProductionInputs(manifest);
+  else await rollbackProductionInputs(manifest);
+  console.log(JSON.stringify({ ok: true, mode, manifest }));
+} else {
+  const [sourceRoot, stateRoot, configFile] = process.argv.slice(2);
+  if (!sourceRoot || !stateRoot || !configFile) {
+    throw new Error("Usage: sync-production-context <source-root> <state-root> <config-file>");
+  }
+  console.log(JSON.stringify(
+    await syncProductionInputs(sourceRoot, stateRoot, configFile),
+    null,
+    2,
+  ));
 }
-
-console.log(JSON.stringify(
-  await syncProductionInputs(sourceRoot, stateRoot, configFile),
-  null,
-  2,
-));

--- a/src/operations/test/production-inputs.test.ts
+++ b/src/operations/test/production-inputs.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, expect, test } from "bun:test";
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
-import { syncProductionInputs } from "../production-inputs";
+import { rollbackProductionInputs, syncProductionInputs } from "../production-inputs";
 
 const temporaryRoot = path.resolve("tmp");
 let directory = "";
@@ -33,6 +33,9 @@ test("synchronization preserves runtime-owned Scout artifacts", async () => {
   expect(await Bun.file(path.join(state, "artifacts", "gig-scout", "descriptions", "source.md")).exists()).toBe(false);
   expect(result.plan.prohibitedDeletes).toBe(0);
   expect(result.plan.runtimeOwnedRoots).toEqual([path.join(state, "artifacts")]);
+  await rollbackProductionInputs(result.plan.transactionManifest);
+  expect(await Bun.file(path.join(state, "profile", "candidate-profile.json")).exists()).toBe(false);
+  expect(await readFile(runtimeArtifact, "utf8")).toBe("runtime\n");
 });
 
 test("synchronization restores every source-managed input after a partial failure", async () => {

--- a/src/operations/test/production-inputs.test.ts
+++ b/src/operations/test/production-inputs.test.ts
@@ -78,3 +78,23 @@ test("rollback rejects transaction targets outside the declared production input
   await writeFile(manifest, JSON.stringify({ version: 1, backups: [] }));
   await expect(rollbackProductionInputs(manifest, source, state, config)).rejects.toThrow("incomplete");
 });
+
+test("rollback rejects tampered existence metadata for the external config", async () => {
+  const source = path.join(directory, "source");
+  const state = path.join(directory, "state");
+  const config = path.join(directory, "config", "config.json");
+  await mkdir(path.join(source, "profile"), { recursive: true });
+  await mkdir(state, { recursive: true });
+  await mkdir(path.dirname(config), { recursive: true });
+  await writeFile(path.join(source, "profile", "candidate-profile.json"), "{}\n");
+  await writeFile(config, "old config\n");
+  const result = await syncProductionInputs(source, state, config);
+  const manifest = JSON.parse(await readFile(result.plan.transactionManifest, "utf8")) as { backups: Array<{ target: string; existed: boolean }> };
+  const configEntry = manifest.backups.find((entry) => entry.target === config);
+  if (!configEntry) throw new Error("Missing config transaction fixture.");
+  configEntry.existed = false;
+  await writeFile(result.plan.transactionManifest, JSON.stringify({ version: 1, backups: manifest.backups }));
+
+  await expect(rollbackProductionInputs(result.plan.transactionManifest, source, state, config)).rejects.toThrow("existence metadata");
+  expect(await Bun.file(config).exists()).toBe(true);
+});

--- a/src/operations/test/production-inputs.test.ts
+++ b/src/operations/test/production-inputs.test.ts
@@ -33,7 +33,7 @@ test("synchronization preserves runtime-owned Scout artifacts", async () => {
   expect(await Bun.file(path.join(state, "artifacts", "gig-scout", "descriptions", "source.md")).exists()).toBe(false);
   expect(result.plan.prohibitedDeletes).toBe(0);
   expect(result.plan.runtimeOwnedRoots).toEqual([path.join(state, "artifacts")]);
-  await rollbackProductionInputs(result.plan.transactionManifest);
+  await rollbackProductionInputs(result.plan.transactionManifest, source, state, config);
   expect(await Bun.file(path.join(state, "profile", "candidate-profile.json")).exists()).toBe(false);
   expect(await readFile(runtimeArtifact, "utf8")).toBe("runtime\n");
 });
@@ -58,4 +58,21 @@ test("synchronization restores every source-managed input after a partial failur
   expect(await readFile(config, "utf8")).toBe("old config\n");
   expect(await readFile(profile, "utf8")).toBe("old profile\n");
   expect(await readFile(migration, "utf8")).toBe("old migration\n");
+});
+
+test("rollback rejects transaction targets outside the declared production inputs", async () => {
+  const source = path.join(directory, "source");
+  const state = path.join(directory, "state");
+  const config = path.join(directory, "config", "config.json");
+  const manifest = path.join(state, "data", "deployment-inputs-tampered.json");
+  const outside = path.join(directory, "outside.txt");
+  await mkdir(path.join(source, "profile"), { recursive: true });
+  await mkdir(path.dirname(config), { recursive: true });
+  await mkdir(path.dirname(manifest), { recursive: true });
+  await writeFile(path.join(source, "profile", "candidate-profile.json"), "{}\n");
+  await writeFile(outside, "safe\n");
+  await writeFile(manifest, JSON.stringify({ version: 1, backups: [{ target: outside, backup: `${outside}.deploy-backup-test`, existed: true }] }));
+
+  await expect(rollbackProductionInputs(manifest, source, state, config)).rejects.toThrow("unsafe target");
+  expect(await readFile(outside, "utf8")).toBe("safe\n");
 });

--- a/src/operations/test/production-inputs.test.ts
+++ b/src/operations/test/production-inputs.test.ts
@@ -34,3 +34,25 @@ test("synchronization preserves runtime-owned Scout artifacts", async () => {
   expect(result.plan.prohibitedDeletes).toBe(0);
   expect(result.plan.runtimeOwnedRoots).toEqual([path.join(state, "artifacts")]);
 });
+
+test("synchronization restores every source-managed input after a partial failure", async () => {
+  const source = path.join(directory, "source");
+  const state = path.join(directory, "state");
+  const config = path.join(directory, "config", "config.json");
+  const profile = path.join(state, "profile", "candidate-profile.json");
+  const migration = path.join(state, "data", "migration", "0010-meeting-participants.json");
+  await mkdir(path.join(source, "profile"), { recursive: true });
+  await mkdir(path.dirname(config), { recursive: true });
+  await mkdir(path.dirname(profile), { recursive: true });
+  await mkdir(path.dirname(migration), { recursive: true });
+  await writeFile(path.join(source, "config.json"), '{"version":1,"actor":"New"}\n');
+  await writeFile(config, "old config\n");
+  await writeFile(profile, "old profile\n");
+  await writeFile(migration, "old migration\n");
+
+  await expect(syncProductionInputs(source, state, config)).rejects.toThrow();
+
+  expect(await readFile(config, "utf8")).toBe("old config\n");
+  expect(await readFile(profile, "utf8")).toBe("old profile\n");
+  expect(await readFile(migration, "utf8")).toBe("old migration\n");
+});

--- a/src/operations/test/production-inputs.test.ts
+++ b/src/operations/test/production-inputs.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { syncProductionInputs } from "../production-inputs";
+
+const temporaryRoot = path.resolve("tmp");
+let directory = "";
+
+beforeEach(async () => {
+  await mkdir(temporaryRoot, { recursive: true });
+  directory = await mkdtemp(path.join(temporaryRoot, "production-inputs-"));
+});
+
+afterEach(async () => {
+  await rm(directory, { recursive: true, force: true });
+});
+
+test("synchronization preserves runtime-owned Scout artifacts", async () => {
+  const source = path.join(directory, "source");
+  const state = path.join(directory, "state");
+  const config = path.join(directory, "config", "config.json");
+  const runtimeArtifact = path.join(state, "artifacts", "gig-scout", "descriptions", "aa", "runtime.md");
+  await mkdir(path.join(source, "profile"), { recursive: true });
+  await mkdir(path.join(source, "artifacts", "gig-scout", "descriptions"), { recursive: true });
+  await mkdir(path.dirname(runtimeArtifact), { recursive: true });
+  await writeFile(path.join(source, "profile", "candidate-profile.json"), "{}\n");
+  await writeFile(path.join(source, "artifacts", "gig-scout", "descriptions", "source.md"), "source\n");
+  await writeFile(runtimeArtifact, "runtime\n");
+
+  const result = await syncProductionInputs(source, state, config);
+
+  expect(await readFile(runtimeArtifact, "utf8")).toBe("runtime\n");
+  expect(await Bun.file(path.join(state, "artifacts", "gig-scout", "descriptions", "source.md")).exists()).toBe(false);
+  expect(result.plan.prohibitedDeletes).toBe(0);
+  expect(result.plan.runtimeOwnedRoots).toEqual([path.join(state, "artifacts")]);
+});

--- a/src/operations/test/production-inputs.test.ts
+++ b/src/operations/test/production-inputs.test.ts
@@ -75,4 +75,6 @@ test("rollback rejects transaction targets outside the declared production input
 
   await expect(rollbackProductionInputs(manifest, source, state, config)).rejects.toThrow("unsafe target");
   expect(await readFile(outside, "utf8")).toBe("safe\n");
+  await writeFile(manifest, JSON.stringify({ version: 1, backups: [] }));
+  await expect(rollbackProductionInputs(manifest, source, state, config)).rejects.toThrow("incomplete");
 });


### PR DESCRIPTION
Closes #131

## Summary
- stop production input synchronization from replacing runtime-owned artifacts
- snapshot and restore SQLite with runtime artifacts and detect integrity regressions
- document explicit production ownership and safe host-script rollout ordering

## Verification
- `bun run check` (348 tests)
- `bun run build`

## Smoke evidence
- exact HEAD: `abb3fcb25dc75d874a11e637dccadc27ef03069e`
- independent reviewer deterministic: passed, 27 tools, 57 registry validations, restart and hydration passed, 8670 ms
- independent reviewer live: passed, normal response, bounded Scout screening state `needs_user_review`, score 4, 18955 ms

## Deployment safety
After merge, update the operator checkout to the merge containing the corrected `bin/deploy-local.sh` and `bin/sync-production-inputs`. Only that corrected host script may deploy the image. Do not deploy this fix with the old script.