### PR TITLE
Isolate runtime artifacts from deployment

### DIFF
--- a/bin/deploy-local.sh
+++ b/bin/deploy-local.sh
@@ -64,6 +64,7 @@ codex_home=$(CDPATH= cd -- "${codex_home}" && pwd -P)
 require_disjoint_from_artifacts() {
   candidate=$1
   label=$2
+  [ "${candidate}" != / ] || fail "${label} must not contain the runtime artifact root"
   case "${candidate}" in
     "${artifact_root}"|"${artifact_root}"/*)
       fail "${label} must not be inside the runtime artifact root"

--- a/bin/deploy-local.sh
+++ b/bin/deploy-local.sh
@@ -60,6 +60,28 @@ backup_root=$(CDPATH= cd -- "${backup_root}" && pwd -P)
 config_root=$(CDPATH= cd -- "$(dirname -- "${config_file}")" && pwd -P)
 config_file="${config_root}/$(basename "${config_file}")"
 codex_home=$(CDPATH= cd -- "${codex_home}" && pwd -P)
+
+require_disjoint_from_artifacts() {
+  candidate=$1
+  label=$2
+  case "${candidate}" in
+    "${artifact_root}"|"${artifact_root}"/*)
+      fail "${label} must not be inside the runtime artifact root"
+      ;;
+  esac
+  case "${artifact_root}" in
+    "${candidate}"/*)
+      fail "${label} must not contain the runtime artifact root"
+      ;;
+  esac
+}
+
+require_disjoint_from_artifacts "${source_root}" "source context root"
+require_disjoint_from_artifacts "${log_root}" "production log root"
+require_disjoint_from_artifacts "${backup_root}" "production backup root"
+require_disjoint_from_artifacts "${config_file}" "production configuration file"
+require_disjoint_from_artifacts "${codex_home}" "Codex credential directory"
+
 [ -f "${state_root}/data/gig-finder.sqlite" ] \
   || fail "production database does not exist; run bin/bootstrap-production.sh first"
 [ -x "${sync_bin}" ] || fail "production input synchronizer is unavailable: ${sync_bin}"

--- a/bin/deploy-local.sh
+++ b/bin/deploy-local.sh
@@ -7,6 +7,7 @@ image_name=${GIG_FINDER_IMAGE:-ghcr.io/paulmccallick/gig-finder}
 container_name=${GIG_FINDER_CONTAINER_NAME:-gig-finder}
 source_root=${GIG_FINDER_SOURCE_CONTEXT_ROOT:-"${repo_root}/context"}
 state_root=${GIG_FINDER_PRODUCTION_ROOT:-/var/lib/gig-finder}
+artifact_root=${GIG_FINDER_ARTIFACT_ROOT:-"${state_root}/artifacts"}
 log_root=${GIG_FINDER_LOG_ROOT:-/var/log/gig-finder}
 backup_root=${GIG_FINDER_BACKUP_ROOT:-/var/backups/gig-finder}
 config_file=${GIG_FINDER_CONFIG:-/etc/gig-finder/config.json}
@@ -29,6 +30,10 @@ case "${state_root}" in
   /*) ;;
   *) fail "GIG_FINDER_PRODUCTION_ROOT must be an absolute path" ;;
 esac
+case "${artifact_root}" in
+  /*) ;;
+  *) fail "GIG_FINDER_ARTIFACT_ROOT must be an absolute path" ;;
+esac
 case "${log_root}" in
   /*) ;;
   *) fail "GIG_FINDER_LOG_ROOT must be an absolute path" ;;
@@ -47,6 +52,7 @@ case "${codex_home}" in
 esac
 [ -d "${source_root}" ] || fail "source context does not exist: ${source_root}"
 [ -d "${state_root}" ] || fail "production state root does not exist: ${state_root}"
+[ -d "${state_root}/data" ] || fail "production data root does not exist: ${state_root}/data"
 [ -d "${log_root}" ] || fail "production log root does not exist: ${log_root}"
 [ -d "${backup_root}" ] || fail "production backup root does not exist: ${backup_root}"
 [ -d "$(dirname -- "${config_file}")" ] || fail "production configuration root does not exist"
@@ -87,7 +93,7 @@ maintenance() {
     -e GIG_FINDER_CONFIG=/etc/gig-finder/config.json \
     -e LOG_DIRECTORY=/var/log/gig-finder \
     -e GIG_FINDER_BACKUP_ROOT=/var/backups/gig-finder \
-    -v "${state_root}:/var/lib/gig-finder" \
+    -v "${state_root}/data:/var/lib/gig-finder/data" \
     -v "${log_root}:/var/log/gig-finder" \
     -v "${backup_root}:/var/backups/gig-finder" \
     -v "${config_file}:/etc/gig-finder/config.json:ro" \
@@ -98,19 +104,14 @@ if [ "${old_running}" = true ]; then
   "${docker_bin}" stop "${container_name}" >/dev/null
 fi
 
-echo "Creating verified production backup..."
+echo "Creating verified production database backup..."
 if ! maintenance validate; then
   if [ "${old_running}" = true ]; then "${docker_bin}" start "${container_name}" >/dev/null; fi
-  fail "pre-deployment database or runtime-artifact validation failed"
+  fail "pre-deployment database validation failed"
 fi
-if ! artifact_baseline=$(maintenance artifacts); then
-  if [ "${old_running}" = true ]; then "${docker_bin}" start "${container_name}" >/dev/null; fi
-  fail "pre-deployment runtime-artifact inventory failed"
-fi
-echo "${artifact_baseline}"
 if ! backup_output=$(maintenance backup); then
   if [ "${old_running}" = true ]; then "${docker_bin}" start "${container_name}" >/dev/null; fi
-  fail "consistent database and runtime-artifact backup failed"
+  fail "production database backup failed"
 fi
 echo "${backup_output}"
 backup_path=$(printf '%s\n' "${backup_output}" \
@@ -136,13 +137,13 @@ if [ ! -f "${config_file}" ]; then
   if [ "${old_running}" = true ]; then "${docker_bin}" start "${container_name}" >/dev/null; fi
   fail "production configuration was not created"
 fi
-if ! maintenance validate || ! maintenance artifacts "${artifact_baseline}"; then
+if ! maintenance validate; then
   rollback_inputs || fail "integrity validation and source-input rollback failed; prior container remains stopped: ${input_manifest}"
   if [ "${old_running}" = true ]; then "${docker_bin}" start "${container_name}" >/dev/null; fi
   fail "source synchronization introduced an integrity regression"
 fi
 
-if ! maintenance migrate || ! maintenance validate || ! maintenance artifacts "${artifact_baseline}"; then
+if ! maintenance migrate || ! maintenance validate; then
   echo "Migration or validation failed; restoring ${backup_path}..." >&2
   if maintenance restore "${backup_path}"; then
     "${sync_bin}" --rollback "${input_manifest}" "${source_root}" "${state_root}" "${config_file}" || fail "production state restored but source-input rollback failed: ${input_manifest}"
@@ -190,6 +191,7 @@ if ! new_container_id=$("${docker_bin}" run --detach \
   -e GIG_FINDER_BACKUP_ROOT=/var/backups/gig-finder \
   -e CODEX_HOME=/run/codex \
   -v "${state_root}:/var/lib/gig-finder" \
+  --mount "type=bind,source=${artifact_root},target=/var/lib/gig-finder/artifacts" \
   -v "${log_root}:/var/log/gig-finder" \
   -v "${backup_root}:/var/backups/gig-finder" \
   -v "${config_file}:/etc/gig-finder/config.json:ro" \
@@ -217,9 +219,9 @@ if [ "${healthy}" != true ]; then
   fail "new container did not become healthy"
 fi
 
-if ! maintenance validate || ! maintenance artifacts "${artifact_baseline}"; then
+if ! maintenance validate; then
   rollback || true
-  fail "post-cutover database or runtime-artifact validation failed"
+  fail "post-cutover database validation failed"
 fi
 
 "${sync_bin}" --finalize "${input_manifest}" "${source_root}" "${state_root}" "${config_file}"

--- a/bin/deploy-local.sh
+++ b/bin/deploy-local.sh
@@ -7,7 +7,6 @@ image_name=${GIG_FINDER_IMAGE:-ghcr.io/paulmccallick/gig-finder}
 container_name=${GIG_FINDER_CONTAINER_NAME:-gig-finder}
 source_root=${GIG_FINDER_SOURCE_CONTEXT_ROOT:-"${repo_root}/context"}
 state_root=${GIG_FINDER_PRODUCTION_ROOT:-/var/lib/gig-finder}
-artifact_root=${GIG_FINDER_ARTIFACT_ROOT:-"${state_root}/artifacts"}
 log_root=${GIG_FINDER_LOG_ROOT:-/var/log/gig-finder}
 backup_root=${GIG_FINDER_BACKUP_ROOT:-/var/backups/gig-finder}
 config_file=${GIG_FINDER_CONFIG:-/etc/gig-finder/config.json}
@@ -29,10 +28,6 @@ fi
 case "${state_root}" in
   /*) ;;
   *) fail "GIG_FINDER_PRODUCTION_ROOT must be an absolute path" ;;
-esac
-case "${artifact_root}" in
-  /*) ;;
-  *) fail "GIG_FINDER_ARTIFACT_ROOT must be an absolute path" ;;
 esac
 case "${log_root}" in
   /*) ;;
@@ -59,6 +54,7 @@ esac
 [ -d "${codex_home}" ] || fail "Codex credential directory does not exist: ${codex_home}"
 source_root=$(CDPATH= cd -- "${source_root}" && pwd -P)
 state_root=$(CDPATH= cd -- "${state_root}" && pwd -P)
+artifact_root="${state_root}/artifacts"
 log_root=$(CDPATH= cd -- "${log_root}" && pwd -P)
 backup_root=$(CDPATH= cd -- "${backup_root}" && pwd -P)
 config_root=$(CDPATH= cd -- "$(dirname -- "${config_file}")" && pwd -P)

--- a/docs/architecture/decisions/0007-immutable-production-deployment.md
+++ b/docs/architecture/decisions/0007-immutable-production-deployment.md
@@ -18,6 +18,7 @@ flowchart LR
   CI -->|main merge SHA| Image[Docker image in GHCR]
   Image -->|deploy exact tag| Host[Local production container]
   Host --> State["/var/lib/gig-finder"]
+  Host --> Artifacts["persistent artifact mount"]
   Host --> Logs["/var/log/gig-finder"]
   Host --> Backups["/var/backups/gig-finder"]
   Host --> Config["/etc/gig-finder"]
@@ -29,14 +30,16 @@ flowchart LR
 - Production deploys that exact Docker image without rebuilding it locally.
 - Databases, documents, configuration, logs, backups, and credentials remain
   outside the Docker image in operator-managed locations.
-- Before cutover, deployment stops runtime writes; creates and verifies a
-  coupled SQLite-and-runtime-artifact snapshot; runs migrations with the new
-  Docker image; and requires database and registered-artifact validation.
+- Before cutover, deployment stops runtime writes, backs up SQLite, runs
+  database migrations with the new Docker image, and validates the database.
+- Runtime artifacts are a dedicated persistent mount available to the
+  application container. Deployment maintenance cannot mount, enumerate,
+  synchronize, back up, or restore that directory.
 - The replacement must report healthy at the requested revision before the
   previous container is removed.
-- Migration, startup, health, or post-cutover integrity failure restores the
-  matching database and artifact snapshot with the prior container. Bypassing
-  this verified deployment path is unsupported.
+- Migration, startup, health, or post-cutover database failure restores SQLite
+  with the prior container, which reuses the unchanged artifact mount.
+  Bypassing this verified deployment path is unsupported.
 
 ## Consequences
 
@@ -44,6 +47,7 @@ flowchart LR
   image.
 - Pull-request validation and release publication share the same build path.
 - Private state cannot enter source or build artifacts.
-- Database, runtime-artifact, and application rollback remain coupled.
+- Artifact backup and full path/hash integrity auditing are separate operational
+  concerns and do not add work proportional to artifact count to deployment.
 - Deployment depends on Docker registry availability and maintained external
   state, backup, and credential directories.

--- a/docs/architecture/deployment-runbook.md
+++ b/docs/architecture/deployment-runbook.md
@@ -73,16 +73,20 @@ GIG_FINDER_CODEX_HOME=/absolute/codex/home \
   bin/deploy-local.sh sha-<40-character-commit-sha>
 ```
 
-The script pulls the immutable image, stops runtime writes, verifies registered
-artifacts, and creates a matching SQLite-plus-artifact snapshot. It then
+The script pulls the immutable image, stops runtime writes, backs up SQLite,
 synchronizes only explicitly source-managed inputs, migrates and validates the
-state, replaces the container, checks `/healthz` for the requested revision,
-and validates the state again. On failure it restores the matching database and
-artifact snapshot with the prior container. The previous container and recovery
-snapshot remain until post-cutover validation succeeds.
+database, replaces the container, and checks `/healthz` for the requested
+revision. On failure it restores SQLite with the prior container.
 
-The artifact report contains counts only; it does not log document content.
-Known missing files are captured as the pre-deployment baseline so the safety
-fix can be released while recovery is incomplete. Every later phase must be no
-worse than that baseline. New missing, mismatched, unsafe, or unregistered Scout
-description paths abort deployment and retain recovery material.
+Runtime artifacts remain at
+`${GIG_FINDER_ARTIFACT_ROOT:-/var/lib/gig-finder/artifacts}`. Only the
+application container mounts that directory, at
+`/var/lib/gig-finder/artifacts`; deployment maintenance containers mount only
+`/var/lib/gig-finder/data`. Normal deployment therefore does not enumerate,
+copy, replace, back up, restore, or validate artifacts, and its validation cost
+does not grow with the artifact count. The prior and replacement application
+containers reuse the same persistent artifact mount.
+
+Run the explicit artifact integrity command and artifact backups as separate
+operational maintenance. They are intentionally outside the deployment
+critical path.

--- a/docs/architecture/deployment-runbook.md
+++ b/docs/architecture/deployment-runbook.md
@@ -85,7 +85,9 @@ application container mounts that directory, at
 `/var/lib/gig-finder/data`. Normal deployment therefore does not enumerate,
 copy, replace, back up, restore, or validate artifacts, and its validation cost
 does not grow with the artifact count. The prior and replacement application
-containers reuse the same persistent artifact mount.
+containers reuse the same persistent artifact mount. Deployment rejects any
+configured source, log, backup, configuration, or credential path that contains
+or is contained by the canonical artifact path before contacting Docker.
 
 Run the explicit artifact integrity command and artifact backups as separate
 operational maintenance. They are intentionally outside the deployment

--- a/docs/architecture/deployment-runbook.md
+++ b/docs/architecture/deployment-runbook.md
@@ -79,7 +79,7 @@ database, replaces the container, and checks `/healthz` for the requested
 revision. On failure it restores SQLite with the prior container.
 
 Runtime artifacts remain at
-`${GIG_FINDER_ARTIFACT_ROOT:-/var/lib/gig-finder/artifacts}`. Only the
+`/var/lib/gig-finder/artifacts`. Only the
 application container mounts that directory, at
 `/var/lib/gig-finder/artifacts`; deployment maintenance containers mount only
 `/var/lib/gig-finder/data`. Normal deployment therefore does not enumerate,

--- a/docs/architecture/infrastructure.md
+++ b/docs/architecture/infrastructure.md
@@ -66,7 +66,7 @@
   `/var/backups/gig-finder`, and Codex credentials are mounted read-only at
   `/run/codex`.
 - **Documents:** Runtime artifacts use the dedicated persistent host directory
-  `${GIG_FINDER_ARTIFACT_ROOT:-/var/lib/gig-finder/artifacts}`, mounted into the
+  `/var/lib/gig-finder/artifacts`, mounted into the
   application container at `/var/lib/gig-finder/artifacts`. Deployment
   maintenance containers do not receive this mount.
 
@@ -81,7 +81,7 @@ Production deployment and recovery procedures are documented in the
 | configured candidate profile | Source-managed private input | Atomically synchronized |
 | `data/migration/0010-meeting-participants.json` | Source-managed migration input | Atomically synchronized when present |
 | `data/*.sqlite` and queue databases | Runtime | Never synchronized from the repository |
-| `${GIG_FINDER_ARTIFACT_ROOT:-/var/lib/gig-finder/artifacts}/**` | Runtime | Application-only persistent mount; never inspected, synchronized, backed up, or restored by deployment |
+| `/var/lib/gig-finder/artifacts/**` | Runtime | Application-only persistent mount; never inspected, synchronized, backed up, or restored by deployment |
 | logs and temporary materializations | Generated | Kept outside source synchronization |
 
 An unclassified path is not a deployable source input. Deployment code uses an

--- a/docs/architecture/infrastructure.md
+++ b/docs/architecture/infrastructure.md
@@ -65,8 +65,10 @@
   configuration is `/etc/gig-finder/config.json`, backups are under
   `/var/backups/gig-finder`, and Codex credentials are mounted read-only at
   `/run/codex`.
-- **Documents:** Profile documents, managed documents, and Scout artifacts live
-  in the mounted `/var/lib/gig-finder` context and are not embedded in the image.
+- **Documents:** Runtime artifacts use the dedicated persistent host directory
+  `${GIG_FINDER_ARTIFACT_ROOT:-/var/lib/gig-finder/artifacts}`, mounted into the
+  application container at `/var/lib/gig-finder/artifacts`. Deployment
+  maintenance containers do not receive this mount.
 
 Production deployment and recovery procedures are documented in the
 [Deployment runbook](deployment-runbook.md).
@@ -79,8 +81,10 @@ Production deployment and recovery procedures are documented in the
 | configured candidate profile | Source-managed private input | Atomically synchronized |
 | `data/migration/0010-meeting-participants.json` | Source-managed migration input | Atomically synchronized when present |
 | `data/*.sqlite` and queue databases | Runtime | Never synchronized from the repository |
-| `artifacts/**`, including `artifacts/gig-scout/**` | Runtime | Never synchronized from the repository; backed up and restored with SQLite |
+| `${GIG_FINDER_ARTIFACT_ROOT:-/var/lib/gig-finder/artifacts}/**` | Runtime | Application-only persistent mount; never inspected, synchronized, backed up, or restored by deployment |
 | logs and temporary materializations | Generated | Kept outside source synchronization |
 
 An unclassified path is not a deployable source input. Deployment code uses an
 explicit source-input list and must not replace a shared production directory.
+Artifact integrity audits and backups are separate operational workflows rather
+than deployment steps.

--- a/docs/architecture/infrastructure.md
+++ b/docs/architecture/infrastructure.md
@@ -87,4 +87,5 @@ Production deployment and recovery procedures are documented in the
 An unclassified path is not a deployable source input. Deployment code uses an
 explicit source-input list and must not replace a shared production directory.
 Artifact integrity audits and backups are separate operational workflows rather
-than deployment steps.
+than deployment steps. Configurable deployment roots must be disjoint from the
+canonical artifact root.

--- a/src/data/test/deployment-script.test.ts
+++ b/src/data/test/deployment-script.test.ts
@@ -67,7 +67,7 @@ async function runDeployment(options: {
 } = {}) {
   const sourceRoot = path.join(directory, "repository", "context");
   const productionRoot = path.join(directory, "var", "lib", "gig-finder");
-  const artifactRoot = path.join(directory, "runtime-artifacts");
+  const artifactRoot = path.join(productionRoot, "artifacts");
   const logRoot = path.join(directory, "var", "log", "gig-finder");
   const backupRoot = path.join(directory, "var", "backups", "gig-finder");
   const configFile = path.join(directory, "etc", "gig-finder", "config.json");
@@ -114,7 +114,6 @@ async function runDeployment(options: {
     env: {
       ...process.env,
       GIG_FINDER_PRODUCTION_ROOT: productionRoot,
-      GIG_FINDER_ARTIFACT_ROOT: artifactRoot,
       GIG_FINDER_SOURCE_CONTEXT_ROOT: sourceRoot,
       GIG_FINDER_LOG_ROOT: logRoot,
       GIG_FINDER_BACKUP_ROOT: backupRoot,

--- a/src/data/test/deployment-script.test.ts
+++ b/src/data/test/deployment-script.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { chmod, mkdir, mkdtemp, readFile, realpath, rm, symlink, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, readdir, realpath, rm, symlink, writeFile } from "node:fs/promises";
 import path from "node:path";
 
 const repositoryRoot = path.resolve(import.meta.dir, "../../..");
@@ -63,9 +63,11 @@ esac
 async function runDeployment(options: {
   failure?: "migrate" | "health";
   oldContainer?: boolean;
+  artifactCount?: number;
 } = {}) {
   const sourceRoot = path.join(directory, "repository", "context");
   const productionRoot = path.join(directory, "var", "lib", "gig-finder");
+  const artifactRoot = path.join(directory, "runtime-artifacts");
   const logRoot = path.join(directory, "var", "log", "gig-finder");
   const backupRoot = path.join(directory, "var", "backups", "gig-finder");
   const configFile = path.join(directory, "etc", "gig-finder", "config.json");
@@ -79,6 +81,7 @@ async function runDeployment(options: {
   const logPath = path.join(directory, "docker.log");
   const syncLogPath = path.join(directory, "sync.log");
   await mkdir(path.join(productionRoot, "data"), { recursive: true });
+  await mkdir(artifactRoot, { recursive: true });
   await mkdir(sourceRoot, { recursive: true });
   await mkdir(logRoot, { recursive: true });
   await mkdir(backupRoot, { recursive: true });
@@ -88,6 +91,8 @@ async function runDeployment(options: {
   await mkdir(path.dirname(deployScript), { recursive: true });
   await writeFile(path.join(productionRoot, "data", "gig-finder.sqlite"), "fixture");
   await writeFile(configFile, '{}\n');
+  await Promise.all(Array.from({ length: options.artifactCount ?? 0 }, (_, index) =>
+    writeFile(path.join(artifactRoot, `artifact-${index}.md`), `artifact ${index}\n`)));
   const canonicalConfigFile = await realpath(configFile);
   await Promise.all([
     writeFile(deployScript, await readFile(deployScriptSource)),
@@ -109,6 +114,7 @@ async function runDeployment(options: {
     env: {
       ...process.env,
       GIG_FINDER_PRODUCTION_ROOT: productionRoot,
+      GIG_FINDER_ARTIFACT_ROOT: artifactRoot,
       GIG_FINDER_SOURCE_CONTEXT_ROOT: sourceRoot,
       GIG_FINDER_LOG_ROOT: logRoot,
       GIG_FINDER_BACKUP_ROOT: backupRoot,
@@ -143,6 +149,7 @@ async function runDeployment(options: {
     log,
     syncLog,
     productionRoot,
+    artifactRoot,
     logRoot,
     backupRoot,
     configFile,
@@ -178,8 +185,12 @@ describe("local production deployment", () => {
     expect(migrate).toBeLessThan(migrationValidate);
     expect(migrationValidate).toBeLessThan(start);
     expect(result.log).toContain(
-      "-v " + result.productionRoot + ":/var/lib/gig-finder",
+      "-v " + path.join(result.productionRoot, "data") + ":/var/lib/gig-finder/data",
     );
+    expect(result.log).toContain(
+      "--mount type=bind,source=" + result.artifactRoot + ",target=/var/lib/gig-finder/artifacts",
+    );
+    expect(result.log).not.toContain("maintenance.js artifacts");
     expect(result.log).toContain("-v " + result.logRoot + ":/var/log/gig-finder");
     expect(result.log).toContain("-v " + result.backupRoot + ":/var/backups/gig-finder");
     expect(result.log).toContain(
@@ -190,6 +201,20 @@ describe("local production deployment", () => {
     expect(result.syncLog).toMatch(/--finalize .*\/data\/deployment-inputs-a{40}-\d+\.json/);
     expect(result.log).toContain("-v " + path.join(directory, "codex") + ":/run/codex:ro");
     expect(result.stdout + result.stderr).not.toContain(path.join(directory, "codex"));
+  });
+
+  test("does not inspect, copy, or mutate the persistent artifact mount", async () => {
+    const result = await runDeployment({ artifactCount: 1_663 });
+
+    expect(result.exitCode).toBe(0);
+    expect(await readdir(result.artifactRoot)).toHaveLength(1_663);
+    const maintenanceLines = result.log.split("\n")
+      .filter((line) => line.includes("maintenance.js"));
+    expect(maintenanceLines.length).toBeGreaterThan(0);
+    expect(maintenanceLines.every((line) =>
+      line.includes(`${path.join(result.productionRoot, "data")}:/var/lib/gig-finder/data`)
+      && !line.includes(result.artifactRoot)
+      && !line.includes(" artifacts"))).toBe(true);
   });
 
   test("restarts the prior container when migration fails", async () => {
@@ -205,7 +230,7 @@ describe("local production deployment", () => {
   });
 
   test("restores the backup and prior container when health verification fails", async () => {
-    const result = await runDeployment({ failure: "health", oldContainer: true });
+    const result = await runDeployment({ failure: "health", oldContainer: true, artifactCount: 3 });
 
     expect(result.exitCode).not.toBe(0);
     expect(result.stderr).toContain("restoring /var/backups/gig-finder/test.sqlite");
@@ -213,5 +238,6 @@ describe("local production deployment", () => {
     expect(result.log).toContain("rename gig-finder-previous-");
     expect(result.log).toContain("start gig-finder");
     expect(result.syncLog).toMatch(/--rollback .*\/data\/deployment-inputs-a{40}-\d+\.json/);
+    expect(await readdir(result.artifactRoot)).toHaveLength(3);
   });
 });

--- a/src/data/test/deployment-script.test.ts
+++ b/src/data/test/deployment-script.test.ts
@@ -64,12 +64,15 @@ async function runDeployment(options: {
   failure?: "migrate" | "health";
   oldContainer?: boolean;
   artifactCount?: number;
+  backupInsideArtifacts?: boolean;
 } = {}) {
   const sourceRoot = path.join(directory, "repository", "context");
   const productionRoot = path.join(directory, "var", "lib", "gig-finder");
   const artifactRoot = path.join(productionRoot, "artifacts");
   const logRoot = path.join(directory, "var", "log", "gig-finder");
-  const backupRoot = path.join(directory, "var", "backups", "gig-finder");
+  const backupRoot = options.backupInsideArtifacts
+    ? path.join(artifactRoot, "backups")
+    : path.join(directory, "var", "backups", "gig-finder");
   const configFile = path.join(directory, "etc", "gig-finder", "config.json");
   const actualConfigRoot = path.join(directory, "private", "etc");
   const codexHome = path.join(directory, "codex");
@@ -100,6 +103,8 @@ async function runDeployment(options: {
     writeFile(curlPath, fakeCurl),
     writeFile(sleepPath, fakeSleep),
     writeFile(syncPath, fakeSync),
+    writeFile(logPath, ""),
+    writeFile(syncLogPath, ""),
   ]);
   await Promise.all([
     chmod(deployScript, 0o755),
@@ -214,6 +219,15 @@ describe("local production deployment", () => {
       line.includes(`${path.join(result.productionRoot, "data")}:/var/lib/gig-finder/data`)
       && !line.includes(result.artifactRoot)
       && !line.includes(" artifacts"))).toBe(true);
+  });
+
+  test("rejects deploy-owned paths that overlap the artifact mount", async () => {
+    const result = await runDeployment({ backupInsideArtifacts: true });
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain("production backup root must not be inside the runtime artifact root");
+    expect(result.log).toBe("");
+    expect(result.syncLog).toBe("");
   });
 
   test("restarts the prior container when migration fails", async () => {

--- a/src/data/test/deployment-script.test.ts
+++ b/src/data/test/deployment-script.test.ts
@@ -65,14 +65,17 @@ async function runDeployment(options: {
   oldContainer?: boolean;
   artifactCount?: number;
   backupInsideArtifacts?: boolean;
+  backupAtFilesystemRoot?: boolean;
 } = {}) {
   const sourceRoot = path.join(directory, "repository", "context");
   const productionRoot = path.join(directory, "var", "lib", "gig-finder");
   const artifactRoot = path.join(productionRoot, "artifacts");
   const logRoot = path.join(directory, "var", "log", "gig-finder");
-  const backupRoot = options.backupInsideArtifacts
-    ? path.join(artifactRoot, "backups")
-    : path.join(directory, "var", "backups", "gig-finder");
+  const backupRoot = options.backupAtFilesystemRoot
+    ? "/"
+    : options.backupInsideArtifacts
+      ? path.join(artifactRoot, "backups")
+      : path.join(directory, "var", "backups", "gig-finder");
   const configFile = path.join(directory, "etc", "gig-finder", "config.json");
   const actualConfigRoot = path.join(directory, "private", "etc");
   const codexHome = path.join(directory, "codex");
@@ -226,6 +229,15 @@ describe("local production deployment", () => {
 
     expect(result.exitCode).not.toBe(0);
     expect(result.stderr).toContain("production backup root must not be inside the runtime artifact root");
+    expect(result.log).toBe("");
+    expect(result.syncLog).toBe("");
+  });
+
+  test("rejects a deploy-owned filesystem root that contains artifacts", async () => {
+    const result = await runDeployment({ backupAtFilesystemRoot: true });
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain("production backup root must not contain the runtime artifact root");
     expect(result.log).toBe("");
     expect(result.syncLog).toBe("");
   });

--- a/src/operations/maintenance.ts
+++ b/src/operations/maintenance.ts
@@ -1,10 +1,9 @@
 import path from "node:path";
-import { cp, mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { mkdir } from "node:fs/promises";
 import {
   createManagedBackup,
   hasRuntimeArtifactRegression,
   loadLegacyMeetingParticipants,
-  migrateLegacyGigArtifacts,
   migrateDatabase,
   openDatabase,
   resolveGigFinderContext,
@@ -19,9 +18,6 @@ const [command, argument] = process.argv.slice(2);
 
 const output = (value: unknown) => console.log(JSON.stringify(value));
 
-const artifactSnapshotPath = (databaseBackupPath: string) => `${databaseBackupPath}.artifacts`;
-const stateManifestPath = (databaseBackupPath: string) => `${databaseBackupPath}.state.json`;
-
 async function artifactIntegrity() {
   const database = openDatabase(context.database, { create: false });
   try {
@@ -31,82 +27,9 @@ async function artifactIntegrity() {
   }
 }
 
-async function createArtifactSnapshot(databaseBackupPath: string) {
-  const integrity = await artifactIntegrity();
-  const target = artifactSnapshotPath(databaseBackupPath);
-  const temporary = `${target}.tmp-${process.pid}-${Date.now()}`;
-  try {
-    await cp(context.artifacts, temporary, { recursive: true, errorOnExist: true, force: false });
-    await rename(temporary, target);
-  } finally {
-    await rm(temporary, { recursive: true, force: true });
-  }
-  const backupDatabase = openDatabase(databaseBackupPath, { create: false });
-  let snapshotIntegrity;
-  try {
-    snapshotIntegrity = await verifyRuntimeArtifacts(
-      backupDatabase,
-      path.join(target, "gig-scout", "descriptions"),
-    );
-  } finally {
-    backupDatabase.close();
-  }
-  if (JSON.stringify(snapshotIntegrity) !== JSON.stringify(integrity)) {
-    await rm(target, { recursive: true, force: true });
-    throw new Error("Artifact snapshot does not match the pre-backup integrity inventory.");
-  }
-  const manifest = { version: 1, databaseBackupPath, artifactSnapshotPath: target, integrity: snapshotIntegrity };
-  await writeFile(stateManifestPath(databaseBackupPath), `${JSON.stringify(manifest, null, 2)}\n`, { flag: "wx" });
-  return { path: target, integrity: snapshotIntegrity };
-}
-
-async function activateArtifactSnapshot(databaseBackupPath: string) {
-  const source = artifactSnapshotPath(databaseBackupPath);
-  const manifest = JSON.parse(await readFile(stateManifestPath(databaseBackupPath), "utf8")) as {
-    version: number;
-    artifactSnapshotPath: string;
-    integrity: unknown;
-  };
-  if (manifest.version !== 1 || manifest.artifactSnapshotPath !== source) {
-    throw new Error("Backup state manifest does not match the requested database backup.");
-  }
-  const temporary = `${context.artifacts}.restore-${process.pid}-${Date.now()}`;
-  const displaced = `${context.artifacts}.pre-restore-${process.pid}-${Date.now()}`;
-  await cp(source, temporary, { recursive: true, errorOnExist: true, force: false });
-  const backupDatabase = openDatabase(databaseBackupPath, { create: false });
-  try {
-    const staged = await verifyRuntimeArtifacts(
-      backupDatabase,
-      path.join(temporary, "gig-scout", "descriptions"),
-    );
-    if (JSON.stringify(staged) !== JSON.stringify(manifest.integrity)) {
-      throw new Error("Staged runtime artifacts do not match the backup state manifest.");
-    }
-  } finally {
-    backupDatabase.close();
-  }
-  await rename(context.artifacts, displaced);
-  try {
-    await rename(temporary, context.artifacts);
-  } catch (error) {
-    await rename(displaced, context.artifacts);
-    throw error;
-  } finally {
-    await rm(temporary, { recursive: true, force: true });
-  }
-  return {
-    finalize: () => rm(displaced, { recursive: true, force: true }).catch(() => undefined),
-    rollback: async () => {
-      await rm(context.artifacts, { recursive: true, force: true });
-      await rename(displaced, context.artifacts);
-    },
-  };
-}
-
 if (command === "backup") {
   const backup = await createManagedBackup(context.database, context.backups);
-  const artifacts = await createArtifactSnapshot(backup.path);
-  output({ command, ok: true, backup, artifacts });
+  output({ command, ok: true, backup });
 } else if (command === "migrate" || command === "initialize") {
   if (command === "initialize") {
     await mkdir(path.dirname(context.database), { recursive: true });
@@ -118,9 +41,8 @@ if (command === "backup") {
         context.meetingParticipantMigration,
       ),
     });
-    const legacyArtifacts = await migrateLegacyGigArtifacts(database, context.artifacts);
     const validation = validateDatabase(database);
-    output({ command, ok: validation.ok, validation, legacyArtifacts });
+    output({ command, ok: validation.ok, validation });
     if (!validation.ok) process.exitCode = 1;
   } finally {
     database.close();
@@ -129,8 +51,7 @@ if (command === "backup") {
   const database = openDatabase(context.database, { create: false });
   try {
     const validation = validateDatabase(database);
-    const artifacts = await verifyRuntimeArtifacts(database, context.scoutDescriptions);
-    output({ command, ok: validation.ok, validation, artifacts });
+    output({ command, ok: validation.ok, validation });
     if (!validation.ok) process.exitCode = 1;
   } finally {
     database.close();
@@ -139,31 +60,8 @@ if (command === "backup") {
   if (!argument || !path.isAbsolute(argument)) {
     throw new Error("restore requires an absolute managed-backup path.");
   }
-  const activatedArtifacts = await activateArtifactSnapshot(argument);
-  let preRestoreDatabase: string | null = null;
-  try {
-    const restored = await restoreVerifiedBackup(
-      context.database,
-      argument,
-      context.backups,
-    );
-    preRestoreDatabase = restored.preRestore.path;
-    const artifacts = await artifactIntegrity();
-    const manifest = JSON.parse(await readFile(stateManifestPath(argument), "utf8")) as {
-      integrity: unknown;
-    };
-    if (JSON.stringify(artifacts) !== JSON.stringify(manifest.integrity)) {
-      throw new Error("Restored runtime artifact inventory does not match its backup manifest.");
-    }
-    await activatedArtifacts.finalize();
-    output({ command, ok: true, ...restored, artifacts });
-  } catch (error) {
-    if (preRestoreDatabase) {
-      await restoreVerifiedBackup(context.database, preRestoreDatabase, context.backups);
-    }
-    await activatedArtifacts.rollback();
-    throw error;
-  }
+  const restored = await restoreVerifiedBackup(context.database, argument, context.backups);
+  output({ command, ok: true, ...restored });
 } else if (command === "artifacts") {
   const artifacts = await artifactIntegrity();
   if (argument) {


### PR DESCRIPTION
Closes #131

## Summary

- isolate the persistent runtime artifact directory as an application-only bind mount
- remove artifact inventories, snapshots, restores, and legacy artifact mutation from normal deployment maintenance
- keep the explicit full artifact audit available outside deployment
- prove deployment work and command size are independent of a production-scale artifact count

## Verification

- `bun run check` (348 tests)
- `bun run build`
- `bun test src/data/test/deployment-script.test.ts` (4 tests)

## Deployment safety

This PR changes the host deployment script. After merge, update the operator checkout to the exact merge containing the corrected `bin/deploy-local.sh` before deploying any image. Do not deploy this change with the currently checked-out older host script.

Normal deployment never receives the artifact mount in maintenance containers. The application container mounts the fixed host path `/var/lib/gig-finder/artifacts` at the same container path; rollback reuses it unchanged. The path is not configurable into a deploy-owned tree.

<!-- smoke-evidence:start -->
Independent review smoke evidence for exact HEAD `5ac4b988faddd815335235d9c5de76d0c0c94791` from a clean detached worktree:

- `bun run smoke:deterministic`: passed; revision guard matched; 27 tools; 57 registry validations; restart passed; hydration passed; 8,580 ms.
- `bun run smoke:live`: passed; revision guard matched; normal response; read-only tools `[]`; Scout screening reached `needs_user_review` with score 5; 15,318 ms.

Any later commit invalidates both results and requires a new independent review and both smoke commands again.
<!-- smoke-evidence:end -->